### PR TITLE
Support post_dataset() when project in non-default group

### DIFF
--- a/ezomero/ezomero.py
+++ b/ezomero/ezomero.py
@@ -74,9 +74,9 @@ def post_dataset(conn, dataset_name, project_id=None, description=None):
         conn.SERVICE_OPTS.setOmeroGroup('-1')
         project = conn.getObject('Project', project_id)
         if project is not None:
-            conn.SERVICE_OPTS.setOmeroGroup(project.getDetails().group.id.val)
+            set_group(conn, project.getDetails().group.id.val)
         else:
-            conn.SERVICE_OPTS.setOmeroGroup(current_group)
+            set_group(conn, current_group)
 
     dataset = DatasetWrapper(conn, DatasetI())
     dataset.setName(dataset_name)


### PR DESCRIPTION
This use-case may not be something you want to support everywhere,
but this is just an example of how you could support the creation and linking of objects in
a group that isn't your default group.

Currently, this will fail:

```post_dataset(conn, "Child of 120", project_id=120)```

if the `project_id` is not in your current group (your 'default' group or another group where you've done `conn.SERVICE_OPTS.setOmeroGroup(group_id)`).

This PR does a cross-group query to find the project, then uses that to set the group context for creation of the Dataset and linking to Project. Then finally reverts to the original group context.