### PR TITLE
Dealing with non existent or no-permission datasets for cross-group post_dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ In general, you will need to create a `BlitzGateway` object using `omero-py`, su
 
 ### `post_dataset(conn, dataset_name, project_id, description)`
 
-Creates a new dataset. Returns a (new) dataset ID.
+Creates a new dataset. Returns a (new) dataset ID. `project_id` does not need to be in the same group as the user's default group.
 
 ### `post_image(conn, image, image_name, description=None, dataset_id=None, source_image_id=None, channel_list=None)`
 

--- a/ezomero/ezomero.py
+++ b/ezomero/ezomero.py
@@ -67,17 +67,21 @@ def post_dataset(conn, dataset_name, project_id=None, description=None):
         raise TypeError('Dataset description must be a string')
 
     project = None
-    current_group = conn.SERVICE_OPTS.getOmeroGroup()
+    current_group = conn.getGroupFromContext().getId()
     if project_id is not None:
         if type(project_id) is not int:
             raise TypeError('Project ID must be integer')
         conn.SERVICE_OPTS.setOmeroGroup('-1')
         project = conn.getObject('Project', project_id)
         if project is not None:
-            set_group(conn, project.getDetails().group.id.val)
+            ret = set_group(conn, project.getDetails().group.id.val)
+            if ret is False:
+                return None
         else:
             set_group(conn, current_group)
-
+            logging.warning(f'Project {project_id} could not be found (check if you have permissions to it)')
+            return None
+            
     dataset = DatasetWrapper(conn, DatasetI())
     dataset.setName(dataset_name)
     if description is not None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-zeroc-ice36-python==3.6.5
+zeroc-ice==3.6.5
 omero-py==5.6.2
 numpy==1.18.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-zeroc-ice==3.6.5
+zeroc-ice36-python==3.6.5
 omero-py==5.6.2
 numpy==1.18.1

--- a/tests/test_ezomero.py
+++ b/tests/test_ezomero.py
@@ -26,6 +26,12 @@ def test_post_dataset(conn, project_structure, timestamp):
     conn.deleteObjects("Dataset", [did, did2], deleteAnns=True,
                        deleteChildren=True, wait=True)
 
+    # Dataset in non-existing project ID
+    ds_test_name3 = 'test_post_dataset3_' + timestamp
+    pid = 99999999
+    did3 = ezomero.post_dataset(conn, ds_test_name3, project_id=pid)
+    assert did3 == None
+
 
 def test_post_image(conn, project_structure, timestamp, image_fixture):
     # Post image in dataset


### PR DESCRIPTION
Added a few `return None` and some logging for when you look for a dataset and can't find it, or for when you try to switch groups into where the project is and fail (which should never happen, I think?). Function now fails gracefully for non-existent project IDs and project IDs outside the permissions range of current user, and succeeds for project IDs the user has access to and for no project ID (orphaned dataset).