### PR TITLE
Adding support for ROIs

### DIFF
--- a/ezomero/ezomero.py
+++ b/ezomero/ezomero.py
@@ -13,10 +13,16 @@ from pydantic.dataclasses import dataclass
 from pydantic.color import Color
 
 #expose functions for import
-__all__ = ["post_dataset",
+__all__ = ["Point",
+           "Line",
+           "Rectangle",
+           "Ellipse",
+           "Polygon",
+           "post_dataset",
            "post_image",
            "post_map_annotation",
            "post_project",
+           "post_roi",
            "get_image",
            "get_image_ids",
            "get_map_annotation_ids",
@@ -428,7 +434,7 @@ def post_roi(conn, image_id, shapes, name=None, description=None):
     image = conn.getObject('Image', image_id)
     roi.setImage(image._obj)
     roi = conn.getUpdateService().saveAndReturnObject(roi)
-    return roi.getId()
+    return roi.getId().getValue()
 
 
 def _rgba_to_int(color: Color):

--- a/ezomero/ezomero.py
+++ b/ezomero/ezomero.py
@@ -39,6 +39,17 @@ __all__ = ["Point",
 
 # classes
 class Shape(ABC):
+    """
+    An abstract base class used to process data related to shapes.
+    This class should not be instantiated. Shapes should inherit from it
+
+    ...
+
+    Methods
+    ----------
+    configure_shape()
+    Does the configuration of extra arguments on the omero shape
+    """
     def configure_shape(self):
         if self.z is not None:
             self._omero_shape.theZ = rint(self.z)
@@ -55,6 +66,40 @@ class Shape(ABC):
 
 @dataclass(frozen=True)
 class Point(Shape):
+    """
+    A dataclass used to represent a Point shape and create an OMERO equivalent.
+    This dataclass is frozen and should not be modified after instantiation
+
+    ...
+
+    Attributes
+    ----------
+    x: float
+        the x axis position of the point shape in pixels
+    y: float
+        the y axis position of the point shape in pixels
+    z: int, optional
+        the z position of the point in pixels (default is None)
+        Note this is the z plane to which the shape is linked and not the sub-voxel resolution position of your shape
+        If None (the default) is provided, it will not be linked to any z plane
+    c: int, optional
+        the channel index to which the shape is linked (default is None)
+        If None (the default) is provided, it will not be linked to any channel
+    t: int, optional
+        the time frame to which the shape is linked (default is None)
+        If None (the default) is provided, it will not be linked to any time frame
+    fill_color: pydantic Color type, optional
+        the color fill of the shape (default is (10, 10, 10, 0.1))
+        Colors can be specified as a name, a hexadecimal value, RGB/RGBA tuples, RGB/RGBA strings or HSL strings
+        https://pydantic-docs.helpmanual.io/usage/types/#color-type
+    stroke_color: Color, optional
+        the color of the shape edge (default is (255, 255, 255, 1.0))
+    stroke_width: int, optional
+        the width of the shape stroke (default is 1)
+    label: str, optional
+        the label of the shape (default is None)
+    """
+
     x: float = field(metadata={'units': 'PIXELS'})
     y: float = field(metadata={'units': 'PIXELS'})
     z: int = field(default=None)
@@ -74,6 +119,44 @@ class Point(Shape):
 
 @dataclass(frozen=True)
 class Line(Shape):
+    """
+    A dataclass used to represent a Line shape and create an OMERO equivalent.
+    This dataclass is frozen and should not be modified after instantiation
+
+    ...
+
+    Attributes
+    ----------
+    x1: float
+        the x axis position of the start point of the line shape in pixels
+    y1: float
+        the y axis position of the start point of the line shape in pixels
+    x2: float
+        the x axis position of the end point of the line shape in pixels
+    y2: float
+        the y axis position of the end point of the line shape in pixels
+    z: int, optional
+        the z position of the point in pixels (default is None)
+        Note this is the z plane to which the shape is linked and not the sub-voxel resolution position of your shape
+        If None (the default) is provided, it will not be linked to any z plane
+    c: int, optional
+        the channel index to which the shape is linked (default is None)
+        If None (the default) is provided, it will not be linked to any channel
+    t: int, optional
+        the time frame to which the shape is linked (default is None)
+        If None (the default) is provided, it will not be linked to any time frame
+    fill_color: pydantic Color type, optional
+        the color fill of the shape (default is (10, 10, 10, 0.1))
+        Colors can be specified as a name, a hexadecimal value, RGB/RGBA tuples, RGB/RGBA strings or HSL strings
+        https://pydantic-docs.helpmanual.io/usage/types/#color-type
+    stroke_color: Color, optional
+        the color of the shape edge (default is (255, 255, 255, 1.0))
+    stroke_width: int, optional
+        the width of the shape stroke (default is 1)
+    label: str, optional
+        the label of the shape (default is None)
+    """
+
     x1: float = field(metadata={'units': 'PIXELS'})
     y1: float = field(metadata={'units': 'PIXELS'})
     x2: float = field(metadata={'units': 'PIXELS'})
@@ -97,6 +180,44 @@ class Line(Shape):
 
 @dataclass(frozen=True)
 class Rectangle(Shape):
+    """
+    A dataclass used to represent a Rectangle shape and create an OMERO equivalent.
+    This dataclass is frozen and should not be modified after instantiation
+
+    ...
+
+    Attributes
+    ----------
+    x: float
+        the x axis position of the rectangle shape in pixels
+    y: float
+        the y axis position of the rectangle shape in pixels
+    width: float
+        the width (x axis) of the rectangle shape in pixels
+    height: float
+        the height (y axis) of the rectangle shape in pixels
+    z: int, optional
+        the z position of the point in pixels (default is None)
+        Note this is the z plane to which the shape is linked and not the sub-voxel resolution position of your shape
+        If None (the default) is provided, it will not be linked to any z plane
+    c: int, optional
+        the channel index to which the shape is linked (default is None)
+        If None (the default) is provided, it will not be linked to any channel
+    t: int, optional
+        the time frame to which the shape is linked (default is None)
+        If None (the default) is provided, it will not be linked to any time frame
+    fill_color: pydantic Color type, optional
+        the color fill of the shape (default is (10, 10, 10, 0.1))
+        Colors can be specified as a name, a hexadecimal value, RGB/RGBA tuples, RGB/RGBA strings or HSL strings
+        https://pydantic-docs.helpmanual.io/usage/types/#color-type
+    stroke_color: Color, optional
+        the color of the shape edge (default is (255, 255, 255, 1.0))
+    stroke_width: int, optional
+        the width of the shape stroke (default is 1)
+    label: str, optional
+        the label of the shape (default is None)
+    """
+
     x: float = field(metadata={'units': 'PIXELS'})
     y: float = field(metadata={'units': 'PIXELS'})
     width: float = field(metadata={'units': 'PIXELS'})
@@ -120,6 +241,44 @@ class Rectangle(Shape):
 
 @dataclass(frozen=True)
 class Ellipse(Shape):
+    """
+    A dataclass used to represent an Ellipse shape and create an OMERO equivalent.
+    This dataclass is frozen and should not be modified after instantiation
+
+    ...
+
+    Attributes
+    ----------
+    x: float
+        the x axis position of the ellipse shape in pixels
+    y: float
+        the y axis position of the ellipse shape in pixels
+    x-rad: float
+        the x radius of the ellipse shape in pixels
+    y-rad: float
+        the y radius of the ellipse shape in pixels
+    z: int, optional
+        the z position of the point in pixels (default is None)
+        Note this is the z plane to which the shape is linked and not the sub-voxel resolution position of your shape
+        If None (the default) is provided, it will not be linked to any z plane
+    c: int, optional
+        the channel index to which the shape is linked (default is None)
+        If None (the default) is provided, it will not be linked to any channel
+    t: int, optional
+        the time frame to which the shape is linked (default is None)
+        If None (the default) is provided, it will not be linked to any time frame
+    fill_color: pydantic Color type, optional
+        the color fill of the shape (default is (10, 10, 10, 0.1))
+        Colors can be specified as a name, a hexadecimal value, RGB/RGBA tuples, RGB/RGBA strings or HSL strings
+        https://pydantic-docs.helpmanual.io/usage/types/#color-type
+    stroke_color: Color, optional
+        the color of the shape edge (default is (255, 255, 255, 1.0))
+    stroke_width: int, optional
+        the width of the shape stroke (default is 1)
+    label: str, optional
+        the label of the shape (default is None)
+    """
+
     x: float = field(metadata={'units': 'PIXELS'})
     y: float = field(metadata={'units': 'PIXELS'})
     x_rad: float = field(metadata={'units': 'PIXELS'})
@@ -143,6 +302,38 @@ class Ellipse(Shape):
 
 @dataclass(frozen=True)
 class Polygon(Shape):
+    """
+    A dataclass used to represent a Polygon shape and create an OMERO equivalent.
+    This dataclass is frozen and should not be modified after instantiation
+
+    ...
+
+    Attributes
+    ----------
+    points: list of tuples of 2 floats
+        a list of 2 element tuples corresponding to the (x, y) coordinates of each vertex of the polygon
+    z: int, optional
+        the z position of the point in pixels (default is None)
+        Note this is the z plane to which the shape is linked and not the sub-voxel resolution position of your shape
+        If None (the default) is provided, it will not be linked to any z plane
+    c: int, optional
+        the channel index to which the shape is linked (default is None)
+        If None (the default) is provided, it will not be linked to any channel
+    t: int, optional
+        the time frame to which the shape is linked (default is None)
+        If None (the default) is provided, it will not be linked to any time frame
+    fill_color: pydantic Color type, optional
+        the color fill of the shape (default is (10, 10, 10, 0.1))
+        Colors can be specified as a name, a hexadecimal value, RGB/RGBA tuples, RGB/RGBA strings or HSL strings
+        https://pydantic-docs.helpmanual.io/usage/types/#color-type
+    stroke_color: Color, optional
+        the color of the shape edge (default is (255, 255, 255, 1.0))
+    stroke_width: int, optional
+        the width of the shape stroke (default is 1)
+    label: str, optional
+        the label of the shape (default is None)
+    """
+
     points: List[Tuple[float, float]] = field(metadata={'units': 'PIXELS'})
     z: int = field(default=None)
     c: int = field(default=None)

--- a/ezomero/ezomero.py
+++ b/ezomero/ezomero.py
@@ -8,10 +8,9 @@ from omero.rtypes import rlong, rstring, rint, rdouble
 from omero.sys import Parameters
 from abc import ABC
 from dataclasses import field
-from typing import List, Tuple, Any
+from typing import List, Tuple
 from pydantic.dataclasses import dataclass
 from pydantic.color import Color
-from pydantic import BaseModel, PrivateAttr, Field
 
 #expose functions for import
 __all__ = ["Point",

--- a/ezomero/ezomero.py
+++ b/ezomero/ezomero.py
@@ -14,6 +14,10 @@ from pydantic.color import Color
 
 #expose functions for import
 __all__ = ["Point",
+           "Line",
+           "Rectangle",
+           "Ellipse",
+           "Polygon",
            "post_dataset",
            "post_image",
            "post_map_annotation",

--- a/ezomero/ezomero.py
+++ b/ezomero/ezomero.py
@@ -616,13 +616,14 @@ def post_roi(conn, image_id, shapes, name=None, description=None):
     Examples
     --------
     >>> shapes = list()
-    >>> point = Point(x=30.6, y=80.4, name='The place')
+    >>> point = Point(x=30.6, y=80.4)
     >>> shapes.append(point)
     >>> rectangle = Rectangle(x=50.0,
                               y=51.3,
                               width=90,
                               height=40,
                               z=3,
+                              label='The place',
                               fill_color=(255, 10, 10, 0.1),
                               stroke_color='red',
                               stroke_width=2)

--- a/ezomero/ezomero.py
+++ b/ezomero/ezomero.py
@@ -1,9 +1,10 @@
 import logging
 import numpy as np
-from omero.gateway import MapAnnotationWrapper, DatasetWrapper, ProjectWrapper
+from omero.gateway import MapAnnotationWrapper, DatasetWrapper, ProjectWrapper, RoiWrapper
 from omero.model import MapAnnotationI, DatasetI, ProjectI, ProjectDatasetLinkI
 from omero.model import DatasetImageLinkI, ImageI, ExperimenterI
-from omero.rtypes import rlong, rstring
+from omero.model import RoiI, PointI, LengthI, enums
+from omero.rtypes import rlong, rstring, rint, rdouble
 from omero.sys import Parameters
 
 #expose functions for import
@@ -264,6 +265,200 @@ def post_project(conn, project_name, description=None):
         project.setDescription(description)
     project.save()
     return project.getId()
+
+
+def post_roi(conn, image_id, shapes, name=None, description=None):
+    """Create new ROI from a list of shapes and link to an image.
+
+    Parameters
+    ----------
+    conn : ``omero.gateway.BlitzGateway`` object
+        OMERO connection.
+    image_id : int
+        IDs of the image to which the new ROI will be linked.
+    shapes : list of shapes
+        list of shape objects conforming the new ROI
+    name : str, optional
+        Name for the new ROI
+    description : str, optional
+        Description of the new ROI
+
+    Returns
+    -------
+    ROI_id : int
+        ID of newly created ROI
+
+    Examples
+    --------
+    >>> shapes = []
+    >>> point = create_shape_point(x_pos=30.6, y_pos=80.4, name='The place')
+    >>> shapes.append(point)
+    >>> rectangle = create_shape_rectangle(x_pos=50,
+                                           y_pos=51,
+                                           width=90,
+                                           height=40,
+                                           z_pos=3,
+                                           fill_color=(255, 10, 10, 10),
+                                           stroke_color=(255, 20, 20, 255),
+                                           stroke_width=2)
+    >>> shapes.append(rectangle)
+    >>> post_roi(conn, 23, shapes, name='My Cell', description='Very important')
+    234
+    """
+    roi = RoiI()  # TODO: work with wrappers
+    # use the omero.model.ImageI that underlies the 'image' wrapper
+    if name is not None:
+        roi.setName(rstring(name))
+    if description is not None:
+        roi.setDescription(rstring(description))
+    for shape in shapes:
+        roi.addShape(shape)
+    image = conn.getObject('Image', image_id)
+    roi.setImage(image._obj)
+    roi = conn.getUpdateService().saveAndReturnObject(roi)
+    return roi.getId()
+
+
+def _rgba_to_int(red, green, blue, alpha=255):
+    """ Helper function returning the color as an Integer in RGBA encoding """
+    r = red << 24
+    g = green << 16
+    b = blue << 8
+    a = alpha
+    rgba_int = sum([r, g, b, a])
+    if rgba_int > (2**31-1):  # convert to signed 32-bit int
+        rgba_int = rgba_int - 2**32
+
+    return rgba_int
+
+
+def _set_shape_properties(shape, name, fill_color, stroke_color, stroke_width):
+    """ Helper function to apply settings to a shape"""
+    if name:
+        shape.setTextValue(rstring(name))
+    if fill_color:
+        shape.setFillColor(rint(_rgba_to_int(*fill_color)))
+    else:
+        shape.setFillColor(rint(_rgba_to_int(10, 10, 10, 10)))
+    if stroke_color:
+        shape.setStrokeColor(rint(_rgba_to_int(*stroke_color)))
+    else:
+        shape.setStrokeColor(rint(_rgba_to_int(255, 255, 255, 255)))
+    if stroke_width:
+        shape.setStrokeWidth(LengthI(stroke_width, enums.UnitsLength.PIXEL))
+    else:
+        shape.setStrokeWidth(LengthI(1, enums.UnitsLength.PIXEL))
+
+
+def create_shape_point(x_pos, y_pos, z_pos=None, c_pos=None, t_pos=None, name=None,
+                       stroke_color=None):
+    point = PointI()
+    point.x = rdouble(x_pos)
+    point.y = rdouble(y_pos)
+    if z_pos is not None:
+        point.theZ = rint(z_pos)
+    if c_pos is not None:
+        point.theC = rint(c_pos)
+    if t_pos is not None:
+        point.theT = rint(t_pos)
+    _set_shape_properties(shape=point,
+                          name=name,
+                          stroke_color=stroke_color,
+                          fill_color=None,
+                          stroke_width=None)
+    return point
+
+
+def create_shape_line(x1_pos, y1_pos, x2_pos, y2_pos, c_pos=None, z_pos=None, t_pos=None,
+                      name=None, stroke_color=(255, 255, 255, 255), stroke_width=1):
+    line = model.LineI()
+    line.x1 = rtypes.rdouble(x1_pos)
+    line.x2 = rtypes.rdouble(x2_pos)
+    line.y1 = rtypes.rdouble(y1_pos)
+    line.y2 = rtypes.rdouble(y2_pos)
+    line.theZ = rtypes.rint(z_pos)
+    line.theT = rtypes.rint(t_pos)
+    if c_pos is not None:
+        line.theC = rtypes.rint(c_pos)
+    _set_shape_properties(line, name=name,
+                          stroke_color=stroke_color,
+                          stroke_width=stroke_width)
+    return line
+
+
+def create_shape_rectangle(x_pos, y_pos, width, height, z_pos, t_pos,
+                           rectangle_name=None,
+                           fill_color=(10, 10, 10, 255),
+                           stroke_color=(255, 255, 255, 255),
+                           stroke_width=1):
+    rect = model.RectangleI()
+    rect.x = rtypes.rdouble(x_pos)
+    rect.y = rtypes.rdouble(y_pos)
+    rect.width = rtypes.rdouble(width)
+    rect.height = rtypes.rdouble(height)
+    rect.theZ = rtypes.rint(z_pos)
+    rect.theT = rtypes.rint(t_pos)
+    _set_shape_properties(shape=rect, name=rectangle_name,
+                          fill_color=fill_color,
+                          stroke_color=stroke_color,
+                          stroke_width=stroke_width)
+    return rect
+
+
+def create_shape_ellipse(x_pos, y_pos, x_radius, y_radius, z_pos, t_pos,
+                         ellipse_name=None,
+                         fill_color=(10, 10, 10, 255),
+                         stroke_color=(255, 255, 255, 255),
+                         stroke_width=1):
+    ellipse = model.EllipseI()
+    ellipse.setX(rtypes.rdouble(x_pos))
+    ellipse.setY(rtypes.rdouble(y_pos))  # TODO: setters and getters everywhere
+    ellipse.radiusX = rtypes.rdouble(x_radius)
+    ellipse.radiusY = rtypes.rdouble(y_radius)
+    ellipse.theZ = rtypes.rint(z_pos)
+    ellipse.theT = rtypes.rint(t_pos)
+    _set_shape_properties(ellipse, name=ellipse_name,
+                          fill_color=fill_color,
+                          stroke_color=stroke_color,
+                          stroke_width=stroke_width)
+    return ellipse
+
+
+def create_shape_polygon(points_list, z_pos, t_pos,
+                         polygon_name=None,
+                         fill_color=(10, 10, 10, 255),
+                         stroke_color=(255, 255, 255, 255),
+                         stroke_width=1):
+    polygon = model.PolygonI()
+    points_str = "".join(["".join([str(x), ',', str(y), ', ']) for x, y in points_list])[:-2]
+    polygon.points = rtypes.rstring(points_str)
+    polygon.theZ = rtypes.rint(z_pos)
+    polygon.theT = rtypes.rint(t_pos)
+    _set_shape_properties(polygon, name=polygon_name,
+                          fill_color=fill_color,
+                          stroke_color=stroke_color,
+                          stroke_width=stroke_width)
+    return polygon
+
+
+def create_shape_mask(mask_array, x_pos, y_pos, z_pos, t_pos,
+                      mask_name=None,
+                      fill_color=(10, 10, 10, 255)):
+    mask = model.MaskI()
+    mask.setX(rtypes.rdouble(x_pos))
+    mask.setY(rtypes.rdouble(y_pos))
+    mask.setTheZ(rtypes.rint(z_pos))
+    mask.setTheT(rtypes.rint(t_pos))
+    mask.setWidth(rtypes.rdouble(mask_array.shape[0]))
+    mask.setHeight(rtypes.rdouble(mask_array.shape[1]))
+    mask.setFillColor(rtypes.rint(_rgba_to_int(*fill_color)))
+    if mask_name:
+        mask.setTextValue(rtypes.rstring(mask_name))
+    mask_packed = np.packbits(mask_array)  # TODO: raise error when not boolean array
+    mask.setBytes(mask_packed.tobytes())
+
+    return mask
+
 
 
 # gets

--- a/ezomero/ezomero.py
+++ b/ezomero/ezomero.py
@@ -8,16 +8,13 @@ from omero.rtypes import rlong, rstring, rint, rdouble
 from omero.sys import Parameters
 from abc import ABC
 from dataclasses import field
-from typing import List, Tuple
+from typing import List, Tuple, Any
 from pydantic.dataclasses import dataclass
 from pydantic.color import Color
+from pydantic import BaseModel, PrivateAttr, Field
 
 #expose functions for import
 __all__ = ["Point",
-           "Line",
-           "Rectangle",
-           "Ellipse",
-           "Polygon",
            "post_dataset",
            "post_image",
            "post_map_annotation",
@@ -42,17 +39,7 @@ __all__ = ["Point",
 
 
 # classes
-@dataclass(frozen=True)
 class Shape(ABC):
-    z: int = field(default=None)
-    c: int = field(default=None)
-    t: int = field(default=None)
-    name: str = field(default=None)
-    fill_color: Color = field(default=Color((10, 10, 10, 0.1)))
-    stroke_color: Color = field(default=Color((255, 255, 255, 1.0)))
-    stroke_width: int = field(default=1)
-    label: str = field(default=None)
-
     def configure_shape(self):
         if self.z is not None:
             self._omero_shape.theZ = rint(self.z)
@@ -60,8 +47,8 @@ class Shape(ABC):
             self._omero_shape.theC = rint(self.c)
         if self.t is not None:
             self._omero_shape.theT = rint(self.t)
-        if self.name is not None:
-            self._omero_shape.setTextValue(rstring(self.name))
+        if self.label is not None:
+            self._omero_shape.setTextValue(rstring(self.label))
         self._omero_shape.setFillColor(rint(_rgba_to_int(self.fill_color)))
         self._omero_shape.setStrokeColor(rint(_rgba_to_int(self.stroke_color)))
         self._omero_shape.setStrokeWidth(LengthI(self.stroke_width, enums.UnitsLength.PIXEL))
@@ -69,13 +56,18 @@ class Shape(ABC):
 
 @dataclass(frozen=True)
 class Point(Shape):
-    x: float = field(default=None, metadata={'units': 'PIXELS'})
-    y: float = field(default=None, metadata={'units': 'PIXELS'})
-    _omero_shape = PointI()
+    x: float = field(metadata={'units': 'PIXELS'})
+    y: float = field(metadata={'units': 'PIXELS'})
+    z: int = field(default=None)
+    c: int = field(default=None)
+    t: int = field(default=None)
+    fill_color: Color = field(default=Color((10, 10, 10, 0.1)))
+    stroke_color: Color = field(default=Color((255, 255, 255, 1.0)))
+    stroke_width: int = field(default=1)
+    label: str = field(default=None)
 
     def __post_init_post_parse__(self):
-        if None in [self.x, self.y]:
-            raise ValueError('Not all necessary arguments are provided')
+        super().__setattr__('_omero_shape', PointI())
         self._omero_shape.x = rdouble(self.x)
         self._omero_shape.y = rdouble(self.y)
         self.configure_shape()
@@ -83,15 +75,20 @@ class Point(Shape):
 
 @dataclass(frozen=True)
 class Line(Shape):
-    x1: float = field(default=None, metadata={'units': 'PIXELS'})
-    y1: float = field(default=None, metadata={'units': 'PIXELS'})
-    x2: float = field(default=None, metadata={'units': 'PIXELS'})
-    y2: float = field(default=None, metadata={'units': 'PIXELS'})
-    _omero_shape = LineI()
+    x1: float = field(metadata={'units': 'PIXELS'})
+    y1: float = field(metadata={'units': 'PIXELS'})
+    x2: float = field(metadata={'units': 'PIXELS'})
+    y2: float = field(metadata={'units': 'PIXELS'})
+    z: int = field(default=None)
+    c: int = field(default=None)
+    t: int = field(default=None)
+    fill_color: Color = field(default=Color((10, 10, 10, 0.1)))
+    stroke_color: Color = field(default=Color((255, 255, 255, 1.0)))
+    stroke_width: int = field(default=1)
+    label: str = field(default=None)
 
     def __post_init_post_parse__(self):
-        if None in [self.x1, self.x2, self.y1, self.y2]:
-            raise ValueError('Not all necessary arguments are provided')
+        super().__setattr__('_omero_shape', LineI())
         self._omero_shape.x1 = rdouble(self.x1)
         self._omero_shape.x2 = rdouble(self.x2)
         self._omero_shape.y1 = rdouble(self.y1)
@@ -101,15 +98,20 @@ class Line(Shape):
 
 @dataclass(frozen=True)
 class Rectangle(Shape):
-    x: float = field(default=None, metadata={'units': 'PIXELS'})
-    y: float = field(default=None, metadata={'units': 'PIXELS'})
-    width: float = field(default=None, metadata={'units': 'PIXELS'})
-    height: float = field(default=None, metadata={'units': 'PIXELS'})
-    _omero_shape = RectangleI()
+    x: float = field(metadata={'units': 'PIXELS'})
+    y: float = field(metadata={'units': 'PIXELS'})
+    width: float = field(metadata={'units': 'PIXELS'})
+    height: float = field(metadata={'units': 'PIXELS'})
+    z: int = field(default=None)
+    c: int = field(default=None)
+    t: int = field(default=None)
+    fill_color: Color = field(default=Color((10, 10, 10, 0.1)))
+    stroke_color: Color = field(default=Color((255, 255, 255, 1.0)))
+    stroke_width: int = field(default=1)
+    label: str = field(default=None)
 
     def __post_init_post_parse__(self):
-        if None in [self.x, self.y, self.width, self.height]:
-            raise ValueError('Not all necessary arguments are provided')
+        super().__setattr__('_omero_shape', RectangleI())
         self._omero_shape.x = rdouble(self.x)
         self._omero_shape.y = rdouble(self.y)
         self._omero_shape.width = rdouble(self.width)
@@ -119,15 +121,20 @@ class Rectangle(Shape):
 
 @dataclass(frozen=True)
 class Ellipse(Shape):
-    x: float = field(default=None, metadata={'units': 'PIXELS'})
-    y: float = field(default=None, metadata={'units': 'PIXELS'})
-    x_rad: float = field(default=None, metadata={'units': 'PIXELS'})
-    y_rad: float = field(default=None, metadata={'units': 'PIXELS'})
-    _omero_shape = EllipseI()
+    x: float = field(metadata={'units': 'PIXELS'})
+    y: float = field(metadata={'units': 'PIXELS'})
+    x_rad: float = field(metadata={'units': 'PIXELS'})
+    y_rad: float = field(metadata={'units': 'PIXELS'})
+    z: int = field(default=None)
+    c: int = field(default=None)
+    t: int = field(default=None)
+    fill_color: Color = field(default=Color((10, 10, 10, 0.1)))
+    stroke_color: Color = field(default=Color((255, 255, 255, 1.0)))
+    stroke_width: int = field(default=1)
+    label: str = field(default=None)
 
     def __post_init_post_parse__(self):
-        if None in [self.x, self.y, self.x_rad, self.y_rad]:
-            raise ValueError('Not all necessary arguments are provided')
+        super().__setattr__('_omero_shape', EllipseI())
         self._omero_shape.x = rdouble(self.x)
         self._omero_shape.y = rdouble(self.y)
         self._omero_shape.radiusX = rdouble(self.x_rad)
@@ -137,12 +144,17 @@ class Ellipse(Shape):
 
 @dataclass(frozen=True)
 class Polygon(Shape):
-    points: List[Tuple[float, float]] = field(default=None, metadata={'units': 'PIXELS'})
-    _omero_shape = PolygonI()
+    points: List[Tuple[float, float]] = field(metadata={'units': 'PIXELS'})
+    z: int = field(default=None)
+    c: int = field(default=None)
+    t: int = field(default=None)
+    fill_color: Color = field(default=Color((10, 10, 10, 0.1)))
+    stroke_color: Color = field(default=Color((255, 255, 255, 1.0)))
+    stroke_width: int = field(default=1)
+    label: str = field(default=None)
 
     def __post_init_post_parse__(self):
-        if self.points is None:
-            raise ValueError('Not all necessary arguments are provided')
+        super().__setattr__('_omero_shape', PolygonI())
         points_str = "".join("".join([str(x), ',', str(y), ', ']) for x, y in self.points)[:-2]
         self._omero_shape.points = rstring(points_str)
         self.configure_shape()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 zeroc-ice==3.6.5
 omero-py==5.6.2
 numpy==1.18.1
+pydantic==1.7.3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -212,3 +212,18 @@ def project_structure(conn, timestamp, image_fixture):
             'plate': plate_id,
             'well': well_id,
             'im1': im_id1})
+
+
+@pytest.fixture(scope='session')
+def roi_fixture():
+    point = ezomero.Point(x=90, y=100)
+    red_point = ezomero.Point(x=110.4, y=100, z=10, t=0, stroke_color='red')
+    line = ezomero.Line(x1=80, y1=80, x2=120, y2=120)
+    green_line = ezomero.Line(x1=70, y1=70, x2=130, y2=130, stroke_color=(0, 255, 0))
+    rectangle = ezomero.Rectangle(x=50, y=50, width=100, height=100)
+    blue_rectangle = ezomero.Rectangle(x=70, y=70, width=60, height=60, stroke_color=(0, 0, 255), fill_color=(0, 0, 0, 0.1))
+
+    shapes = [point, red_point, line, green_line, rectangle, blue_rectangle]
+
+    return shapes
+

--- a/tests/test_ezomero.py
+++ b/tests/test_ezomero.py
@@ -10,7 +10,7 @@ def test_omero_connection(conn, omero_params):
 # Test posts
 ############
 def test_post_dataset(conn, project_structure, timestamp):
-    # Orphaned dataset, with descripion
+    # Orphaned dataset, with description
     ds_test_name = 'test_post_dataset_' + timestamp
     did = ezomero.post_dataset(conn, ds_test_name, description='New test')
     assert conn.getObject("Dataset", did).getName() == ds_test_name
@@ -75,6 +75,14 @@ def test_post_project_type(conn):
         _ = ezomero.post_project(conn, 123)
     with pytest.raises(TypeError):
         _ = ezomero.post_project(conn, '123', description=1245)
+
+
+def test_post_roi(conn, project_structure, roi_fixture):
+    im_id = project_structure['im']
+    roi_id = ezomero.post_roi(conn, im_id, roi_fixture)
+    roi_in_omero = conn.getObject('Roi', roi_id)
+    conn.deleteObjects("Roi", [roi_in_omero], deleteAnns=True,
+                       deleteChildren=True, wait=True)
 
 
 # Test gets

--- a/tests/test_ezomero.py
+++ b/tests/test_ezomero.py
@@ -81,6 +81,7 @@ def test_post_roi(conn, project_structure, roi_fixture):
     im_id = project_structure['im']
     roi_id = ezomero.post_roi(conn, im_id, roi_fixture)
     roi_in_omero = conn.getObject('Roi', roi_id)
+    assert roi_in_omero.sizeOfShapes == len(roi_fixture)
     conn.deleteObjects("Roi", [roi_in_omero], deleteAnns=True,
                        deleteChildren=True, wait=True)
 

--- a/tests/test_users_group.py
+++ b/tests/test_users_group.py
@@ -1,0 +1,9 @@
+import ezomero
+
+
+def test_ug(conn, users_groups):
+    group_info, user_info = users_groups
+    gid = ezomero.get_group_id(conn, group_info[0][0])
+    assert group_info[0][1] == gid
+    uid = ezomero.get_user_id(conn, user_info[0][0])
+    assert user_info[0][1] == uid


### PR DESCRIPTION
I reformated some code I had to add support for posting ROIs:
- Created a few dataclasses for the shapes
- Created a method to post a list of shapes as a ROI
- I use pydantic as a library to validate types. I like it a lot but it adds a dependency to the ezomero. It is though one of the well supported libraries of python and behind FastAPI.
- As it is, pydantic is going to cast inputs into the correct type, which could lead to confussion in some cases. If you pass a z position to a point of 3.6, it will be casted to the int 3 that OMERO is needing. We might change that behaviour easily.
- The shape dataclasses are frozen, to avoid (as far as we can) modification of the shape after saving it into OMERO. I guess we could keep track of all of this, but, is it a common need? I don't think so. 