### PR TITLE
Adding automatic unit testing with a github action

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,0 +1,22 @@
+name: Run Tests
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Run docker compose up
+        run: docker-compose -f tests/docker-compose.yml up -d
+      - name: Set up Python 3.6
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.6
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8 pytest
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Test with pytest
+        run: |
+          pytest tests/

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,5 +1,5 @@
 name: Run Tests
-on: push
+on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![Run Tests](https://github.com/TheJacksonLaboratory/ezomero/workflows/Run%20Tests/badge.svg?event=push)
+
 # ezomero
 A module with convenience functions for writing Python code that interacts with OMERO.
 

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -35,3 +35,4 @@ networks:
 volumes:
   database:
   omero:
+  

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -24,8 +24,8 @@ services:
     networks:
       - omero
     ports:
-      - "4063:4063"
-      - "4064:4064"
+      - "6063:4063"
+      - "6064:4064"
     volumes:
       - "omero:/OMERO"
 

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,0 +1,37 @@
+version: "3"
+
+services:
+
+  database:
+    image: "postgres:11"
+    environment:
+      POSTGRES_USER: omero
+      POSTGRES_DB: omero
+      POSTGRES_PASSWORD: omero
+    networks:
+      - omero
+    volumes:
+      - "database:/var/lib/postgresql/data"
+
+  omeroserver:
+    image: "openmicroscopy/omero-server:5.6"
+    environment:
+      CONFIG_omero_db_host: database
+      CONFIG_omero_db_user: omero
+      CONFIG_omero_db_pass: omero
+      CONFIG_omero_db_name: omero
+      ROOTPASS: omero
+    networks:
+      - omero
+    ports:
+      - "4063:4063"
+      - "4064:4064"
+    volumes:
+      - "omero:/OMERO"
+
+networks:
+  omero:
+
+volumes:
+  database:
+  omero:


### PR DESCRIPTION
We can use a docker-compose with some containers (postgres, omero-server from OME) to spin up an ephemeral OMERO server and run our tests (located on the `tests/` folder) against it. The github action triggers on any push or PR. (also added a cool badge to readme)