### PR TITLE
Improve project/dataset/image fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,23 +82,23 @@ def omero_params(request):
 @pytest.fixture(scope='session')
 def users_groups(conn, omero_params):
     session_uuid = conn.getSession().getUuid().val
+    user = omero_params[0]
     host = omero_params[2]
-    port = omero_params[3]
+    port = str(omero_params[3])
     cli = CLI()
-    cli.register('sessions', SessionsControl, 'TEST')
+    cli.register('sessions', SessionsControl, 'test')
     cli.register('user', UserControl, 'test')
     cli.register('group', GroupControl, 'test')
-
-    cli.invoke(['sessions', 'login',
-                '-k', session_uuid,
-                '-s', host,
-                '-p', str(port)])
 
     group_info = []
     for gname, gperms in GROUPS_TO_CREATE:
         cli.invoke(['group', 'add',
                     gname,
-                    '--type', gperms])
+                    '--type', gperms,
+                    '-k', session_uuid,
+                    '-u', user,
+                    '-s', host,
+                    '-p', port])
         gid = ezomero.get_group_id(conn, gname)
         group_info.append([gname, gid])
 
@@ -111,14 +111,22 @@ def users_groups(conn, omero_params):
                     'tester',
                     '--group-name', groups_add[0],
                     '-e', 'useremail@jax.org',
-                    '-P', 'abc123'])
+                    '-P', 'abc123',
+                    '-k', session_uuid,
+                    '-u', user,
+                    '-s', host,
+                    '-p', port])
 
         # add user to rest of groups
         if len(groups_add) > 1:
             for group in groups_add[1:]:
                 cli.invoke(['group', 'adduser',
                             '--user-name', user,
-                            '--name', group])
+                            '--name', group,
+                            '-k', session_uuid,
+                            '-u', user,
+                            '-s', host,
+                            '-p', port])
 
         # make user owner of listed groups
         if len(groups_own) > 0:
@@ -126,11 +134,13 @@ def users_groups(conn, omero_params):
                 cli.invoke(['group', 'adduser',
                             '--user-name', user,
                             '--name', group,
-                            '--as-owner'])
+                            '--as-owner',
+                            '-k', session_uuid,
+                            '-u', user,
+                            '-s', host,
+                            '-p', port])
         uid = ezomero.get_user_id(conn, user)
         user_info.append([user, uid])
-
-    cli.invoke(['sessions', 'logout'])
 
     return (group_info, user_info)
 
@@ -161,6 +171,7 @@ def timestamp():
 @pytest.fixture(scope='session')
 def project_structure(conn, timestamp, image_fixture, users_groups,
                       omero_params):
+    group_info, user_info = users_groups
     # Don't change anything for default_user!
     # If you change anything about users/groups, make sure they exist
     # [[group, [projects]], ...] per user
@@ -338,6 +349,7 @@ def project_structure(conn, timestamp, image_fixture, users_groups,
     for pname, pid in project_info:
         conn.deleteObjects("Project", [pid], deleteAnns=True,
                            deleteChildren=True, wait=True)
+
 
 @pytest.fixture(scope='session')
 def screen_structure(conn, timestamp, image_fixture):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,22 +43,29 @@ USERS_TO_CREATE = [
                    ]
                   ]
 
-# Project->Dataset->Image fixture based on the following
-# Be very careful when changing -- you could break the tests!
-# Note: 'TMSP' is replaced with a timestamp (from fixture)
-
 
 def pytest_addoption(parser):
-    parser.addoption("--omero-user", action="store",
-        default=os.environ.get("OMERO_USER", DEFAULT_OMERO_USER))
-    parser.addoption("--omero-pass", action="store",
-        default=os.environ.get("OMERO_PASS", DEFAULT_OMERO_PASS))
-    parser.addoption("--omero-host", action="store",
-        default=os.environ.get("OMERO_HOST", DEFAULT_OMERO_HOST))
-    parser.addoption("--omero-port", action="store", type=int,
-        default=int(os.environ.get("OMERO_PORT", DEFAULT_OMERO_PORT)))
-    parser.addoption("--omero-secure", action="store",
-        default=bool(os.environ.get("OMERO_SECURE", DEFAULT_OMERO_SECURE)))
+    parser.addoption("--omero-user",
+                     action="store",
+                     default=os.environ.get("OMERO_USER",
+                                            DEFAULT_OMERO_USER))
+    parser.addoption("--omero-pass",
+                     action="store",
+                     default=os.environ.get("OMERO_PASS",
+                                            DEFAULT_OMERO_PASS))
+    parser.addoption("--omero-host",
+                     action="store",
+                     default=os.environ.get("OMERO_HOST",
+                                            DEFAULT_OMERO_HOST))
+    parser.addoption("--omero-port",
+                     action="store",
+                     type=int,
+                     default=int(os.environ.get("OMERO_PORT",
+                                                DEFAULT_OMERO_PORT)))
+    parser.addoption("--omero-secure",
+                     action="store",
+                     default=bool(os.environ.get("OMERO_SECURE",
+                                                 DEFAULT_OMERO_SECURE)))
 
 
 # we can change this later
@@ -154,25 +161,135 @@ def timestamp():
 @pytest.fixture(scope='session')
 def project_structure(conn, timestamp, image_fixture, users_groups):
     # [[group, [projects]], ...] per user
-    project_str = [
-                   ['default_user',
-                    [
-                     ['default_group', ['proj0_TMSP']]
-                     ]
-                    ],
-                   ['test_user1',
-                    [
-                     ['test_group_1', ['proj1_TMSP', 'proj2_TMSP']],
-                     ['test_group_2', ['proj3_TMSP']]
-                     ]
-                    ],
-                   ['test_user2',
-                    [
-                     ['test_group_1', ['proj4_TMSP', 'proj5_TMSP']],
-                     ['test_group_2', ['proj6_TMSP']]
-                     ]
+    project_str = {
+                    'users': [
+                        {
+                            'name': 'default_user',
+                            'groups': [
+                                {
+                                    'name': 'default_group',
+                                    'projects': [
+                                        {
+                                            'name': f'proj0_{timestamp}',
+                                            'datasets': [
+                                                {
+                                                    'name': f'ds0_{timestamp}',
+                                                    'images': [
+                                                        f'im0_{timestamp}'
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            'name': 'test_user1',
+                            'groups': [
+                                {
+                                    'name': 'test_group1',
+                                    'projects': [
+                                        {
+                                            'name': f'proj1_{timestamp}',
+                                            'datasets': [
+                                                {
+                                                    'name': f'ds1_{timestamp}',
+                                                    'images': [
+                                                        f'im1_{timestamp}'
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            'name': f'proj2_{timestamp}',
+                                            'datasets': [
+                                                {
+                                                    'name': '',
+                                                    'images': [
+
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    'name': 'test_group2',
+                                    'projects': [
+                                        {
+                                            'name': f'proj3_{timestamp}',
+                                            'datasets': [
+                                                {
+                                                    'name': f'ds2_{timestamp}',
+                                                    'images': [
+
+                                                    ]
+                                                },
+                                                {
+                                                    'name': f'ds3_{timestamp}',
+                                                    'images': [
+                                                        f'im2_{timestamp}',
+                                                        f'im3_{timestamp}'
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            'name': 'test_user2',
+                            'groups': [
+                                {
+                                    'name': 'test_group1',
+                                    'projects': [
+                                        {
+                                            'name': f'proj4_{timestamp}',
+                                            'datasets': [
+                                                {
+                                                    'name': f'ds4_{timestamp}',
+                                                    'images': [
+                                                        f'im4_{timestamp}'
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            'name': f'proj5_{timestamp}',
+                                            'datasets': [
+                                                {
+                                                    'name': f'ds5_{timestamp}',
+                                                    'images': [
+
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    'name': 'test_group2',
+                                    'projects': [
+                                        {
+                                            'name': f'proj6_{timestamp}',
+                                            'datasets': [
+                                                {
+                                                    'name': f'ds6_{timestamp}',
+                                                    'images': [
+                                                        f'im5_{timestamp}',
+                                                        f'im6_{timestamp}'
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
                     ]
-                  ]
+                  }
 
     # [[project, [datasets]], ...] per user
     dataset_str = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -161,6 +161,8 @@ def timestamp():
 @pytest.fixture(scope='session')
 def project_structure(conn, timestamp, image_fixture, users_groups,
                       omero_params):
+    # Don't change anything for default_user!
+    # If you change anything about users/groups, make sure they exist
     # [[group, [projects]], ...] per user
     project_str = {
                     'users': [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,69 +46,6 @@ USERS_TO_CREATE = [
 # Project->Dataset->Image fixture based on the following
 # Be very careful when changing -- you could break the tests!
 # Note: 'TMSP' is replaced with a timestamp (from fixture)
-# [[group, [projects]], ...] per user
-PROJECT_FIX = [
-               ['default_user',
-                [
-                 ['default_group', ['proj0_TMSP']]
-                 ]
-                ],
-               ['test_user1',
-                [
-                 ['test_group_1', ['proj1_TMSP', 'proj2_TMSP']],
-                 ['test_group_2', ['proj3_TMSP']]
-                 ]
-                ],
-               ['test_user2',
-                [
-                 ['test_group_1', ['proj4_TMSP', 'proj5_TMSP']],
-                 ['test_group_2', ['proj6_TMSP']]
-                 ]
-                ]
-              ]
-
-# [[project, [datasets]], ...] per user
-DATASET_FIX = [
-               ['default_user',
-                [
-                 ['proj0_TMSP', ['ds0_TMSP']]
-                 ]
-                ],
-               ['test_user1',
-                [
-                 ['proj1_TMSP', ['ds1_TMSP']],
-                 ['proj3_TMSP', ['ds2_TMSP', 'ds3_TMSP']]
-                 ]
-                ],
-               ['test_user2',
-                [
-                 ['proj4_TMSP', ['ds4_TMSP']],
-                 ['proj6_TMSP', ['ds5_TMSP', 'ds6_TMSP']]
-                 ]
-                ]
-               ]
-
-# [[dataset, [images]], ...] per user
-IMAGE_FIX = [
-               ['default_user',
-                [
-                 ['ds0_TMSP', ['im0_TMSP']]
-                 ]
-                ],
-               ['test_user1',
-                [
-                 ['ds1_TMSP', ['im1_TMSP']],
-                 ['ds3_TMSP', ['im2_TMSP', 'im3_TMSP']]
-                 ]
-                ],
-               ['test_user2',
-                [
-                 ['ds4_TMSP', ['im4_TMSP']],
-                 ['ds6_TMSP', ['im5_TMSP', 'im6_TMSP']]
-                 ]
-                ]
-               ]
-
 
 
 def pytest_addoption(parser):
@@ -216,34 +153,91 @@ def timestamp():
 
 @pytest.fixture(scope='session')
 def project_structure(conn, timestamp, image_fixture, users_groups):
-    """
-    See PROJECT_FIX, DATASET_FIX, and IMAGE_FIX above for layout of test
-    omero objects
+    # [[group, [projects]], ...] per user
+    project_str = [
+                   ['default_user',
+                    [
+                     ['default_group', ['proj0_TMSP']]
+                     ]
+                    ],
+                   ['test_user1',
+                    [
+                     ['test_group_1', ['proj1_TMSP', 'proj2_TMSP']],
+                     ['test_group_2', ['proj3_TMSP']]
+                     ]
+                    ],
+                   ['test_user2',
+                    [
+                     ['test_group_1', ['proj4_TMSP', 'proj5_TMSP']],
+                     ['test_group_2', ['proj6_TMSP']]
+                     ]
+                    ]
+                  ]
 
-    Screen        Plate         Well          Image
-    ------        -----         ----          -----
-    screen ---->  plate ---->   well   ----->  im1
-    """
-    
-    # REPLACE_PROJEC
-    for group, projects in PROJECT_FIX:
-        if group != 'default':
+    # [[project, [datasets]], ...] per user
+    dataset_str = [
+                   ['default_user',
+                    [
+                     ['proj0_TMSP', ['ds0_TMSP']]
+                     ]
+                    ],
+                   ['test_user1',
+                    [
+                     ['proj1_TMSP', ['ds1_TMSP']],
+                     ['proj3_TMSP', ['ds2_TMSP', 'ds3_TMSP']]
+                     ]
+                    ],
+                   ['test_user2',
+                    [
+                     ['proj4_TMSP', ['ds4_TMSP']],
+                     ['proj6_TMSP', ['ds5_TMSP', 'ds6_TMSP']]
+                     ]
+                    ]
+                   ]
 
-    proj_name = "proj_" + timestamp
+    # [[dataset, [images]], ...] per user
+    image_struc = [
+                   ['default_user',
+                    [
+                     ['ds0_TMSP', ['im0_TMSP']]
+                     ]
+                    ],
+                   ['test_user1',
+                    [
+                     ['ds1_TMSP', ['im1_TMSP']],
+                     ['ds3_TMSP', ['im2_TMSP', 'im3_TMSP']]
+                     ]
+                    ],
+                   ['test_user2',
+                    [
+                     ['ds4_TMSP', ['im4_TMSP']],
+                     ['ds6_TMSP', ['im5_TMSP', 'im6_TMSP']]
+                     ]
+                    ]
+                   ]
+
+    # project info
+    for user, group_proj in project_str:
+        #switch user if necessary
+        for group, projects in project_str:
+            if group != 'default':
+        #switch back to original connection
+
+
     proj_id = ezomero.post_project(conn, proj_name)
 
     # REPLACE_DATASET
-    ds_name = "ds_" + timestamp
+
     ds_id = ezomero.post_dataset(conn, ds_name,
                                  project_id=proj_id)
 
     # REPLACE_IMAGES
-    im_name = 'im_' + timestamp
+
     im_id = ezomero.post_image(conn, image_fixture, im_name,
                                dataset_id=ds_id)
 
+    # screen info
     update_service = conn.getUpdateService()
-
     # Create Screen
     screen_name = "screen_" + timestamp
     screen = ScreenWrapper(conn, ScreenI())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -290,68 +290,30 @@ def project_structure(conn, timestamp, image_fixture, users_groups):
                         }
                     ]
                   }
+    project_info = []
+    dataset_info = []
+    image_info = []
+    for user in project_str['users']:
+        username = user['name']
+        for group in user['groups']:
+            groupname = group['name']
+            # spin connection here if not default:
+            for project in group['projects']:
+                projname = project['name']
+                # post project and add projname and id to list
+                for dataset in project['datasets']:
+                    dsname = dataset['name']
+                    # post dataset and add dsname and id to list
+                    for imname in dataset['images']:
+                        # post image and add im id to list
+                        print()
+            # close connection here if not default
 
-    # [[project, [datasets]], ...] per user
-    dataset_str = [
-                   ['default_user',
-                    [
-                     ['proj0_TMSP', ['ds0_TMSP']]
-                     ]
-                    ],
-                   ['test_user1',
-                    [
-                     ['proj1_TMSP', ['ds1_TMSP']],
-                     ['proj3_TMSP', ['ds2_TMSP', 'ds3_TMSP']]
-                     ]
-                    ],
-                   ['test_user2',
-                    [
-                     ['proj4_TMSP', ['ds4_TMSP']],
-                     ['proj6_TMSP', ['ds5_TMSP', 'ds6_TMSP']]
-                     ]
-                    ]
-                   ]
-
-    # [[dataset, [images]], ...] per user
-    image_struc = [
-                   ['default_user',
-                    [
-                     ['ds0_TMSP', ['im0_TMSP']]
-                     ]
-                    ],
-                   ['test_user1',
-                    [
-                     ['ds1_TMSP', ['im1_TMSP']],
-                     ['ds3_TMSP', ['im2_TMSP', 'im3_TMSP']]
-                     ]
-                    ],
-                   ['test_user2',
-                    [
-                     ['ds4_TMSP', ['im4_TMSP']],
-                     ['ds6_TMSP', ['im5_TMSP', 'im6_TMSP']]
-                     ]
-                    ]
-                   ]
-
-    # project info
-    for user, group_proj in project_str:
-        #switch user if necessary
-        for group, projects in project_str:
-            if group != 'default':
-        #switch back to original connection
-
-
-    proj_id = ezomero.post_project(conn, proj_name)
-
-    # REPLACE_DATASET
-
-    ds_id = ezomero.post_dataset(conn, ds_name,
-                                 project_id=proj_id)
-
-    # REPLACE_IMAGES
-
-    im_id = ezomero.post_image(conn, image_fixture, im_name,
-                               dataset_id=ds_id)
+    # proj_id = ezomero.post_project(conn, proj_name)
+    # ds_id = ezomero.post_dataset(conn, ds_name,
+    #                              project_id=proj_id)
+    # im_id = ezomero.post_image(conn, image_fixture, im_name,
+    #                            dataset_id=ds_id)
 
     # screen info
     update_service = conn.getUpdateService()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -333,8 +333,11 @@ def project_structure(conn, timestamp, image_fixture, users_groups,
             if username != 'default_user':
                 current_conn.close()
 
-    return [project_info, dataset_info, image_info]
-
+    yield [project_info, dataset_info, image_info]
+    conn.SERVICE_OPTS.setOmeroGroup(-1)
+    for pname, pid in project_info:
+        conn.deleteObjects("Project", [pid], deleteAnns=True,
+                           deleteChildren=True, wait=True)
 
 @pytest.fixture(scope='session')
 def screen_structure(conn, timestamp, image_fixture):
@@ -373,4 +376,7 @@ def screen_structure(conn, timestamp, image_fixture):
     well_obj = update_service.saveAndReturnObject(well)
     well_id = well_obj.getId().getValue()
 
-    return [plate_id, well_id, im_id1]
+    yield [plate_id, well_id, im_id1, screen_id]
+    conn.SERVICE_OPTS.setOmeroGroup(-1)
+    conn.deleteObjects("Screen", [screen_id], deleteAnns=True,
+                       deleteChildren=True, wait=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -159,7 +159,8 @@ def timestamp():
 
 
 @pytest.fixture(scope='session')
-def project_structure(conn, timestamp, image_fixture, users_groups):
+def project_structure(conn, timestamp, image_fixture, users_groups,
+                      omero_params):
     # [[group, [projects]], ...] per user
     project_str = {
                     'users': [
@@ -188,7 +189,7 @@ def project_structure(conn, timestamp, image_fixture, users_groups):
                             'name': 'test_user1',
                             'groups': [
                                 {
-                                    'name': 'test_group1',
+                                    'name': 'test_group_1',
                                     'projects': [
                                         {
                                             'name': f'proj1_{timestamp}',
@@ -215,7 +216,7 @@ def project_structure(conn, timestamp, image_fixture, users_groups):
                                     ]
                                 },
                                 {
-                                    'name': 'test_group2',
+                                    'name': 'test_group_2',
                                     'projects': [
                                         {
                                             'name': f'proj3_{timestamp}',
@@ -243,7 +244,7 @@ def project_structure(conn, timestamp, image_fixture, users_groups):
                             'name': 'test_user2',
                             'groups': [
                                 {
-                                    'name': 'test_group1',
+                                    'name': 'test_group_1',
                                     'projects': [
                                         {
                                             'name': f'proj4_{timestamp}',
@@ -270,7 +271,7 @@ def project_structure(conn, timestamp, image_fixture, users_groups):
                                     ]
                                 },
                                 {
-                                    'name': 'test_group2',
+                                    'name': 'test_group_2',
                                     'projects': [
                                         {
                                             'name': f'proj6_{timestamp}',
@@ -301,7 +302,7 @@ def project_structure(conn, timestamp, image_fixture, users_groups):
 
             # New connection if user and group need to be specified
             if username != 'default_user':
-                current_conn = conn.suConn(username=username, group=groupname)
+                current_conn = conn.suConn(username, groupname)
 
             # Loop to post projects, datasets, and images
             for project in group['projects']:
@@ -323,7 +324,7 @@ def project_structure(conn, timestamp, image_fixture, users_groups):
                         im_id = ezomero.post_image(current_conn,
                                                    image_fixture,
                                                    imname,
-                                                   ds_id)
+                                                   dataset_id=ds_id)
                         image_info.append([imname, im_id])
 
             # Close temporary connection if it was created

--- a/tests/test_ezomero.py
+++ b/tests/test_ezomero.py
@@ -10,6 +10,7 @@ def test_omero_connection(conn, omero_params):
 # Test posts
 ############
 def test_post_dataset(conn, project_structure, timestamp):
+
     # Orphaned dataset, with descripion
     ds_test_name = 'test_post_dataset_' + timestamp
     did = ezomero.post_dataset(conn, ds_test_name, description='New test')
@@ -18,7 +19,8 @@ def test_post_dataset(conn, project_structure, timestamp):
 
     # Dataset in project, no description
     ds_test_name2 = 'test_post_dataset2_' + timestamp
-    pid = project_structure['proj']
+    project_info = project_structure[0]
+    pid = project_info[0][1]
     did2 = ezomero.post_dataset(conn, ds_test_name2, project_id=pid)
     ds = conn.getObjects("Dataset", opts={'project': pid})
     ds_names = [d.getName() for d in ds]

--- a/tests/test_ezomero.py
+++ b/tests/test_ezomero.py
@@ -30,11 +30,13 @@ def test_post_dataset(conn, project_structure, timestamp):
 
 
 def test_post_image(conn, project_structure, timestamp, image_fixture):
+    dataset_info = project_structure[1]
+    did = dataset_info[0][1]
     # Post image in dataset
     image_name = 'test_post_image_' + timestamp
     im_id = ezomero.post_image(conn, image_fixture, image_name,
                                description='This is an image',
-                               dataset_id=project_structure["ds"])
+                               dataset_id=did)
     assert conn.getObject("Image", im_id).getName() == image_name
 
     # Post orphaned image
@@ -45,11 +47,12 @@ def test_post_image(conn, project_structure, timestamp, image_fixture):
 
 
 def test_post_get_map_annotation(conn, project_structure):
+    image_info = project_structure[2]
+    im_id = image_info[0][1]
     # This test both ezomero.post_map_annotation and ezomero.get_map_annotation
     kv = {"key1": "value1",
           "key2": "value2"}
     ns = "jax.org/omeroutils/tests/v0"
-    im_id = project_structure['im']
     map_ann_id = ezomero.post_map_annotation(conn, "Image", im_id, kv, ns)
     kv_pairs = ezomero.get_map_annotation(conn, map_ann_id)
     assert kv_pairs["key2"] == "value2"
@@ -83,7 +86,8 @@ def test_post_project_type(conn):
 ###########
 
 def test_get_image(conn, project_structure):
-    im_id = project_structure['im']
+    image_info = project_structure[2]
+    im_id = image_info[0][1]
     # test default
     im, im_arr = ezomero.get_image(conn, im_id)
     assert im.getId() == im_id
@@ -120,17 +124,19 @@ def test_get_image(conn, project_structure):
                                        pad=False)
 
 
-def test_get_image_ids(conn, project_structure):
+def test_get_image_ids(conn, project_structure, screen_structure):
+    dataset_info = project_structure[1]
+    main_ds_id = dataset_info[0][1]
+    image_info = project_structure[2]
+    im_id = image_info[0][1]
     # Based on dataset ID
-    main_ds_id = project_structure['ds']
-    im_id = project_structure['im']
     im_ids = ezomero.get_image_ids(conn, dataset=main_ds_id)
     assert im_ids[0] == im_id
     assert len(im_ids) == 1
 
     # Based on well ID
-    well_id = project_structure['well']
-    im_id1 = project_structure['im1']
+    well_id = screen_structure[1]
+    im_id1 = screen_structure[2]
     im_ids = ezomero.get_image_ids(conn, well=well_id)
     assert im_ids[0] == im_id1
     assert len(im_ids) == 1
@@ -146,7 +152,8 @@ def test_get_map_annotation_ids(conn, project_structure):
     kv = {"key1": "value1",
           "key2": "value2"}
     ns = "jax.org/omeroutils/tests/v0"
-    im_id = project_structure['im']
+    image_info = project_structure[2]
+    im_id = image_info[0][1]
     map_ann_id = ezomero.post_map_annotation(conn, "Image", im_id, kv, ns)
     map_ann_id2 = ezomero.post_map_annotation(conn, "Image", im_id, kv, ns)
     map_ann_id3 = ezomero.post_map_annotation(conn, "Image", im_id, kv, ns)
@@ -180,7 +187,8 @@ def test_put_map_annotation(conn, project_structure):
     kv = {"key1": "value1",
           "key2": "value2"}
     ns = "jax.org/omeroutils/tests/v0"
-    im_id = project_structure['im']
+    image_info = project_structure[2]
+    im_id = image_info[0][1]
     map_ann_id = ezomero.post_map_annotation(conn, "Image", im_id, kv, ns)
     kv = {"key1": "changed1",
           "key2": "value2"}

--- a/tests/test_users_group.py
+++ b/tests/test_users_group.py
@@ -4,6 +4,7 @@ import ezomero
 def test_ug(conn, users_groups):
     group_info, user_info = users_groups
     gid = ezomero.get_group_id(conn, group_info[0][0])
+    assert gid is not None
     assert group_info[0][1] == gid
     uid = ezomero.get_user_id(conn, user_info[0][0])
     assert user_info[0][1] == uid


### PR DESCRIPTION
This PR changes how the prepopulated project/dataset/image structures work for the tests. Now, this structure is created from `json`, which lives inside the `project_structure` fixture.

Screen/Plate/Well/Image is now broken out into a separate `screen_structure` fixture