### PR TITLE
Cross group queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,17 +17,17 @@ In general, you will need to create a `BlitzGateway` object using `omero-py`, su
 
 ## `post` functions
 
-### `post_dataset(conn, dataset_name, project_id, description)`
+### `post_dataset(conn, dataset_name, project_id, description, across_groups=True)`
 
-Creates a new dataset. Returns a (new) dataset ID. `project_id` does not need to be in the same group as the user's default group.
+Creates a new dataset. Returns a (new) dataset ID. `project_id` does not need to be in the same group as the current `conn` group if `across_groups` is `True`.
 
-### `post_image(conn, image, image_name, description=None, dataset_id=None, source_image_id=None, channel_list=None)`
+### `post_image(conn, image, image_name, description=None, dataset_id=None, source_image_id=None, channel_list=None, across_groups=True)`
 
-Creates a new OMERO image from a numpy array. Returns a (new) image ID.
+Creates a new OMERO image from a numpy array. Returns a (new) image ID. `dataset_id` does not need to be in the same group as the current `conn` group if `across_groups` is `True`.
 
-### `post_map_annotation(conn, object_type, object_ids, kv_dict, ns)`
+### `post_map_annotation(conn, object_type, object_id, kv_dict, ns, across_groups=True)`
 
-Creates a new MapAnnotation and links to images. Returns a (new) MapAnnotation ID.
+Creates a new MapAnnotation and links to images. Returns a (new) MapAnnotation ID. `object_id` does not need to be in the same group as the current `conn` group if `across_groups` is `True`.
 
 ### `post_project(conn, project_name, description=None)`
 
@@ -35,39 +35,39 @@ Creates a new project. Returns a (new) project ID.
 
 ## `get` functions
 
-### `get_image(conn, image_id, no_pixels=False, start_coords=None, axis_lengths=None, xyzct=False, pad=False)`
+### `get_image(conn, image_id, no_pixels=False, start_coords=None, axis_lengths=None, xyzct=False, pad=False, across_groups=True)`
 
-Gets omero image object along with pixels as a numpy array. Returns an `omero.gateway.ImageWrapper` object along with an `ndarray` containing the image pixels.
+Gets omero image object along with pixels as a numpy array. Returns an `omero.gateway.ImageWrapper` object along with an `ndarray` containing the image pixels. `image_id` does not need to be in the same group as the current `conn` group if `across_groups` is `True`.
 
-### `get_image_ids(conn, dataset=None, well=None)`
+### `get_image_ids(conn, dataset=None, well=None, across_groups=True)`
 
-Returns a list of image ids based on project and dataset. Returns a list of `int`s with the desired IDs.
+Returns a list of image ids based on project and dataset. Returns a list of `int`s with the desired IDs. `dataset` does not need to be in the same group as the current `conn` group if `across_groups` is `True`.
 
-### `get_map_annotation_ids(conn, object_type, object_id, ns=None)`
+### `get_map_annotation_ids(conn, object_type, object_id, ns=None, across_groups=True)`
 
-Get IDs of map annotations associated with an object. Returns a list of `int`s with the desired IDs.
+Get IDs of map annotations associated with an object. Returns a list of `int`s with the desired IDs. `object_id` does not need to be in the same group as the current `conn` group if `across_groups` is `True`.
 
-### `get_map_annotation(conn, map_ann_id)`
+### `get_map_annotation(conn, map_ann_id, across_groups=True)`
 
-Get the value of a map annotation object. Returns a `dict` with the contents of the desired `MapAnnotation`.
+Get the value of a map annotation object. Returns a `dict` with the contents of the desired `MapAnnotation`. `map_ann_id` does not need to be in the same group as the current `conn` group if `across_groups` is `True`.
 
 ### `get_group_id(conn, group_name)`
 
 Get ID of a group based on group name. Must be an exact match. Case sensitive. Returns a single `int`.
 
-### `get_user_id(conn, user_name)`
+### `get_user_id(conn, user_name, across_groups=True)`
 
-Get ID of a user based on username. Must be an exact match. Case sensitive. Returns a single `int`.
+Get ID of a user based on username. Must be an exact match. Case sensitive. Returns a single `int`. `user_name` does not need to be in the same group as the current `conn` group if `across_groups` is `True`.
 
-### `get_original_filepaths(conn, image_id, fpath='repo')`
+### `get_original_filepaths(conn, image_id, fpath='repo', across_groups=True)`
 
-Get paths to original files for specified image. Returns a `list` of `str`.
+Get paths to original files for specified image. Returns a `list` of `str`. `image_id` does not need to be in the same group as the current `conn` group if `across_groups` is `True`.
 
 ## `put` functions
 
-### `put_map_annotation(conn, map_ann_id, kv_dict, ns=None)`
+### `put_map_annotation(conn, map_ann_id, kv_dict, ns=None, across_groups=True)`
 
-Update an existing map annotation with new values (kv pairs). 
+Update an existing map annotation with new values (kv pairs). `map_ann_id` does not need to be in the same group as the current `conn` group if `across_groups` is `True`.
 
 ## Filter functions
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Creates a new OMERO image from a numpy array. Returns a (new) image ID. `dataset
 
 ### `post_map_annotation(conn, object_type, object_id, kv_dict, ns, across_groups=True)`
 
-Creates a new MapAnnotation and links to images. Returns a (new) MapAnnotation ID. `object_id` does not need to be in the same group as the current `conn` group if `across_groups` is `True`.
+Creates a new MapAnnotation and links to an object. Returns a (new) MapAnnotation ID. `object_id` does not need to be in the same group as the current `conn` group if `across_groups` is `True`.
 
 ### `post_project(conn, project_name, description=None)`
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ In general, you will need to create a `BlitzGateway` object using `omero-py`, su
 
 ### `post_dataset(conn, dataset_name, project_id, description)`
 
-Creates a new dataset. Returns a (new) dataset ID.
+Creates a new dataset. Returns a (new) dataset ID. `project_id` does not need to be in the same group as the user's default group.
 
 ### `post_image(conn, image, image_name, description=None, dataset_id=None, source_image_id=None, channel_list=None)`
 

--- a/ezomero/ezomero.py
+++ b/ezomero/ezomero.py
@@ -270,7 +270,7 @@ def post_map_annotation(conn, object_type, object_ids, kv_dict, ns, across_group
     map_ann = MapAnnotationWrapper(conn)
     map_ann.setNs(str(ns))
     map_ann.setValue(kv_pairs)
-    map_ann.save()
+    
     objs = conn.getObjects(object_type, object_ids)
     if objs is not None:
         for o in objs:
@@ -278,6 +278,7 @@ def post_map_annotation(conn, object_type, object_ids, kv_dict, ns, across_group
             if ret is False:
                 logging.warning(f'Cannot change into group where object {o.getDetails().id.val} is. Skipping.')
                 continue
+            map_ann.save()
             o.linkAnnotation(map_ann)
     else:
         logging.warning(f'Objects {object_ids} could not be found (check if you have permissions to them)')

--- a/ezomero/ezomero.py
+++ b/ezomero/ezomero.py
@@ -398,8 +398,14 @@ def get_image(conn, image_id, no_pixels=False, start_coords=None,
     >>> im_object.getId()
     314
     """
+
+    if image_id is None:
+        raise TypeError('Object ID cannot be empty')
     pixel_view = None
     image = conn.getObject('Image', image_id)
+    if image is None:
+        logging.warning(f'Cannot load image {image_id} - check if you have permissions to do so')
+        return (None, None)
     size_x = image.getSizeX()
     size_y = image.getSizeY()
     size_z = image.getSizeZ()
@@ -762,7 +768,8 @@ def get_original_filepaths(conn, image_id, fpath='repo', across_groups=True):
 
 
 # puts
-def put_map_annotation(conn, map_ann_id, kv_dict, ns=None):
+@do_across_groups
+def put_map_annotation(conn, map_ann_id, kv_dict, ns=None, across_groups=True):
     """Update an existing map annotation with new values (kv pairs)
 
     Parameters
@@ -795,6 +802,9 @@ def put_map_annotation(conn, map_ann_id, kv_dict, ns=None):
     >>> put_map_annotation(conn, 16, new_values, 'test_v2')
     """
     map_ann = conn.getObject('MapAnnotation', map_ann_id)
+    if map_ann is None:
+        raise ValueError("MapAnnotation is non-existent or you do not have permissions to change it.")
+        return None
 
     if ns is None:
         ns = map_ann.getNs()

--- a/ezomero/ezomero.py
+++ b/ezomero/ezomero.py
@@ -333,8 +333,9 @@ def post_project(conn, project_name, description=None):
 
 
 # gets
+@do_across_groups
 def get_image(conn, image_id, no_pixels=False, start_coords=None,
-              axis_lengths=None, xyzct=False, pad=False):
+              axis_lengths=None, xyzct=False, pad=False, across_groups=True):
     """Get omero image object along with pixels as a numpy array.
 
     Parameters
@@ -475,7 +476,8 @@ def get_image(conn, image_id, no_pixels=False, start_coords=None,
     return (image, pixel_view)
 
 
-def get_image_ids(conn, dataset=None, well=None):
+@do_across_groups
+def get_image_ids(conn, dataset=None, well=None, across_groups=True):
     """Return a list of image ids based on image container
 
     If neither dataset nor well is specified, function will return orphans.
@@ -559,8 +561,8 @@ def get_image_ids(conn, dataset=None, well=None):
 
     return [r[0].val for r in results]
 
-
-def get_map_annotation_ids(conn, object_type, object_id, ns=None):
+@do_across_groups
+def get_map_annotation_ids(conn, object_type, object_id, ns=None, across_groups=True):
     """Get IDs of map annotations associated with an object
 
     Parameters
@@ -649,8 +651,8 @@ def get_group_id(conn, group_name):
             return g.getId()
     return None
 
-
-def get_user_id(conn, user_name):
+@do_across_groups
+def get_user_id(conn, user_name, across_groups=True):
     """Get ID of a user based on user name.
 
     Must be an exact match. Case sensitive.
@@ -680,8 +682,8 @@ def get_user_id(conn, user_name):
             return u.getId()
     return None
 
-
-def get_original_filepaths(conn, image_id, fpath='repo'):
+@do_across_groups
+def get_original_filepaths(conn, image_id, fpath='repo', across_groups=True):
     """Get paths to original files for specified image.
 
     Parameters

--- a/ezomero/ezomero.py
+++ b/ezomero/ezomero.py
@@ -67,17 +67,21 @@ def post_dataset(conn, dataset_name, project_id=None, description=None):
         raise TypeError('Dataset description must be a string')
 
     project = None
-    current_group = conn.SERVICE_OPTS.getOmeroGroup()
+    current_group = conn.getGroupFromContext().getId()
     if project_id is not None:
         if type(project_id) is not int:
             raise TypeError('Project ID must be integer')
         conn.SERVICE_OPTS.setOmeroGroup('-1')
         project = conn.getObject('Project', project_id)
         if project is not None:
-            set_group(conn, project.getDetails().group.id.val)
+            ret = set_group(conn, project.getDetails().group.id.val)
+            if ret is False:
+                return None
         else:
             set_group(conn, current_group)
-
+            logging.warning(f'Project {project_id} could not be found (check if you have permissions to it)')
+            return None
+            
     dataset = DatasetWrapper(conn, DatasetI())
     dataset.setName(dataset_name)
     if description is not None:

--- a/ezomero/ezomero.py
+++ b/ezomero/ezomero.py
@@ -38,6 +38,18 @@ __all__ = ["post_dataset",
 
 
 def get_default_args(func):
+    """Retrieves the default arguments of a function.
+
+    Parameters
+    ----------
+    func : function 
+        Function whose signature we want to inspect
+
+    Returns
+    -------
+    _ : dict
+        Key-value pairs of argument name and value.
+    """
     signature = inspect.signature(func)
     return {
         k: v.default
@@ -47,6 +59,19 @@ def get_default_args(func):
 
 
 def do_across_groups(f):
+    """Decorator functional for making functions work across
+    OMERO groups.
+
+    Parameters
+    ----------
+    f : function 
+        Function that will be decorated
+
+    Returns
+    -------
+    wrapper : Object
+        Return value of the decorated function.
+    """
     def wrapper(*args, **kwargs):
         defaults = get_default_args(f)
         if defaults['across_groups'] or kwargs['across_groups']:
@@ -78,8 +103,12 @@ def post_dataset(conn, dataset_name, project_id=None, description=None, across_g
     project_id : int, optional
         Id of Project in which to create the Dataset. If no Project is
         specified, the Dataset will be orphaned.
-    description : str
+    description : str, optional
         Description for the new Dataset.
+    across_groups : bool, optional
+        Defines cross-group behavior of function - set to 
+        ``False`` to disable it.
+
 
     Returns
     -------
@@ -154,6 +183,9 @@ def post_image(conn, image, image_name, description=None, dataset_id=None,
         ``image`` parameter.
     channel_list : list of ints
         Copies metadata from these channels in source image (if specified).
+    across_groups : bool, optional
+        Defines cross-group behavior of function - set to 
+        ``False`` to disable it.
 
     Returns
     -------
@@ -237,6 +269,9 @@ def post_map_annotation(conn, object_type, object_id, kv_dict, ns, across_groups
         key-value pairs that will be included in the MapAnnotation
     ns : str
         Namespace for the MapAnnotation
+    across_groups : bool, optional
+        Defines cross-group behavior of function - set to 
+        ``False`` to disable it.
 
     Notes
     -----
@@ -369,6 +404,9 @@ def get_image(conn, image_id, no_pixels=False, start_coords=None,
         If `axis_lengths` values would result in out-of-bounds indices, pad
         pixel array with zeros. Otherwise, such an operation will raise an
         exception. Ignored if `no_pixels` is True.
+    across_groups : bool, optional
+        Defines cross-group behavior of function - set to 
+        ``False`` to disable it.
 
     Returns
     -------
@@ -503,6 +541,9 @@ def get_image_ids(conn, dataset=None, well=None, across_groups=True):
         ID of Dataset from which to return image IDs.
     well : int, optional
         ID of Well from which to return image IDs.
+    across_groups : bool, optional
+        Defines cross-group behavior of function - set to 
+        ``False`` to disable it.
 
     Returns
     -------
@@ -588,6 +629,9 @@ def get_map_annotation_ids(conn, object_type, object_id, ns=None, across_groups=
         ID of object of ``object_type``.
     ns : str
         Namespace with which to filter results
+    across_groups : bool, optional
+        Defines cross-group behavior of function - set to 
+        ``False`` to disable it.
 
     Returns
     -------
@@ -619,6 +663,9 @@ def get_map_annotation(conn, map_ann_id, across_groups=True):
         OMERO connection.
     map_ann_id : int
         ID of map annotation to get.
+    across_groups : bool, optional
+        Defines cross-group behavior of function - set to 
+        ``False`` to disable it.
 
     Returns
     -------
@@ -676,6 +723,9 @@ def get_user_id(conn, user_name, across_groups=True):
         OMERO connection.
     user_name : str
         Name of the user for which an ID is to be returned.
+    across_groups : bool, optional
+        Defines cross-group behavior of function - set to 
+        ``False`` to disable it.
 
     Returns
     -------
@@ -710,6 +760,9 @@ def get_original_filepaths(conn, image_id, fpath='repo', across_groups=True):
         repository ('repo') or the path from which the image was imported
         ('client'). The latter is useful for images that were imported by
         the "in place" method. Defaults to 'repo'.
+    across_groups : bool, optional
+        Defines cross-group behavior of function - set to 
+        ``False`` to disable it.
 
     Notes
     -----
@@ -783,6 +836,9 @@ def put_map_annotation(conn, map_ann_id, kv_dict, ns=None, across_groups=True):
     ns : str
         New namespace for the MapAnnotation. If left as None, the old
         namespace will be used.
+    across_groups : bool, optional
+        Defines cross-group behavior of function - set to 
+        ``False`` to disable it.
 
     Notes
     -----

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-zeroc-ice36-python==3.6.5
+zeroc-ice==3.6.5
 omero-py==5.6.2
 numpy==1.18.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-zeroc-ice==3.6.5
+zeroc-ice36-python==3.6.5
 omero-py==5.6.2
 numpy==1.18.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ from omero.model import ScreenPlateLinkI
 from omero.plugins.sessions import SessionsControl
 from omero.plugins.user import UserControl
 from omero.plugins.group import GroupControl
-from omero.rtypes import rint
+from omero.rtypes import rint, rstring
 
 # Settings for OMERO
 DEFAULT_OMERO_USER = "root"
@@ -42,6 +42,7 @@ USERS_TO_CREATE = [
                     []
                    ]
                   ]
+
 
 
 def pytest_addoption(parser):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -346,10 +346,12 @@ def project_structure(conn, timestamp, image_fixture, users_groups,
                 current_conn.close()
 
     yield [project_info, dataset_info, image_info]
+    current_group = conn.getGroupFromContext().getId()
     conn.SERVICE_OPTS.setOmeroGroup(-1)
     for pname, pid in project_info:
         conn.deleteObjects("Project", [pid], deleteAnns=True,
                            deleteChildren=True, wait=True)
+    conn.SERVICE_OPTS.setOmeroGroup(current_group)
 
 
 @pytest.fixture(scope='session')
@@ -362,7 +364,6 @@ def screen_structure(conn, timestamp, image_fixture):
     screen.setName(screen_name)
     screen.save()
     screen_id = screen.getId()
-
     # Create Plate
     plate_name = "plate_" + timestamp
     plate = PlateWrapper(conn, PlateI())
@@ -390,6 +391,8 @@ def screen_structure(conn, timestamp, image_fixture):
     well_id = well_obj.getId().getValue()
 
     yield [plate_id, well_id, im_id1, screen_id]
+    current_group = conn.getGroupFromContext().getId()
     conn.SERVICE_OPTS.setOmeroGroup(-1)
     conn.deleteObjects("Screen", [screen_id], deleteAnns=True,
                        deleteChildren=True, wait=True)
+    conn.SERVICE_OPTS.setOmeroGroup(current_group)

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,0 +1,38 @@
+version: "3"
+
+services:
+
+  database:
+    image: "postgres:11"
+    environment:
+      POSTGRES_USER: omero
+      POSTGRES_DB: omero
+      POSTGRES_PASSWORD: omero
+    networks:
+      - omero
+    volumes:
+      - "database:/var/lib/postgresql/data"
+
+  omeroserver:
+    image: "openmicroscopy/omero-server:5.6"
+    environment:
+      CONFIG_omero_db_host: database
+      CONFIG_omero_db_user: omero
+      CONFIG_omero_db_pass: omero
+      CONFIG_omero_db_name: omero
+      ROOTPASS: omero
+    networks:
+      - omero
+    ports:
+      - "6063:4063"
+      - "6064:4064"
+    volumes:
+      - "omero:/OMERO"
+
+networks:
+  omero:
+
+volumes:
+  database:
+  omero:
+  

--- a/tests/test_ezomero.py
+++ b/tests/test_ezomero.py
@@ -26,6 +26,12 @@ def test_post_dataset(conn, project_structure, timestamp):
     conn.deleteObjects("Dataset", [did, did2], deleteAnns=True,
                        deleteChildren=True, wait=True)
 
+    # Dataset in non-existing project ID
+    ds_test_name3 = 'test_post_dataset3_' + timestamp
+    pid = 99999999
+    did3 = ezomero.post_dataset(conn, ds_test_name3, project_id=pid)
+    assert did3 == None
+
 
 def test_post_image(conn, project_structure, timestamp, image_fixture):
     # Post image in dataset

--- a/tests/test_ezomero.py
+++ b/tests/test_ezomero.py
@@ -16,21 +16,23 @@ def test_post_dataset(conn, project_structure, timestamp):
     assert conn.getObject("Dataset", did).getName() == ds_test_name
     assert conn.getObject("Dataset", did).getDescription() == "New test"
 
-    # Dataset in project, no description
+    # Dataset in default project, no description
     ds_test_name2 = 'test_post_dataset2_' + timestamp
     pid = project_structure['proj']
     did2 = ezomero.post_dataset(conn, ds_test_name2, project_id=pid)
     ds = conn.getObjects("Dataset", opts={'project': pid})
     ds_names = [d.getName() for d in ds]
     assert ds_test_name2 in ds_names
-    conn.deleteObjects("Dataset", [did, did2], deleteAnns=True,
-                       deleteChildren=True, wait=True)
 
+    conn.deleteObjects("Dataset", [did, did2], deleteAnns=True,
+                        deleteChildren=True, wait=True)
+    
     # Dataset in non-existing project ID
     ds_test_name3 = 'test_post_dataset3_' + timestamp
     pid = 99999999
     did3 = ezomero.post_dataset(conn, ds_test_name3, project_id=pid)
     assert did3 == None
+
 
 
 def test_post_image(conn, project_structure, timestamp, image_fixture):

--- a/tests/test_ezomero.py
+++ b/tests/test_ezomero.py
@@ -115,8 +115,6 @@ def test_post_image(conn, project_structure, users_groups, timestamp, image_fixt
                        deleteChildren=True, wait=True)
 
 def test_post_get_map_annotation(conn, project_structure, users_groups):
-    print(project_structure)
-    print(users_groups)
     image_info = project_structure[2]
     im_id = image_info[0][1]
     # This test both ezomero.post_map_annotation and ezomero.get_map_annotation
@@ -196,6 +194,13 @@ def test_get_image(conn, project_structure):
     im, im_arr = ezomero.get_image(conn, im_id, no_pixels=True)
     assert im_arr is None
 
+    # test that IndexError comes up when pad=False
+    with pytest.raises(IndexError):
+        im, im_arr = ezomero.get_image(conn, im_id,
+                                       start_coords=(195, 195, 18, 0, 0),
+                                       axis_lengths=(10, 10, 3, 4, 3),
+                                       pad=False)
+
     # test crop
     im, im_arr = ezomero.get_image(conn, im_id,
                                    start_coords=(101, 101, 10, 0, 0),
@@ -210,15 +215,11 @@ def test_get_image(conn, project_structure):
                                    pad=True)
     assert im_arr.shape == (3, 3, 11, 10, 4)
 
-    # test that IndexError comes up when pad=False
-    with pytest.raises(IndexError):
-        im, im_arr = ezomero.get_image(conn, im_id,
-                                       start_coords=(195, 195, 18, 0, 0),
-                                       axis_lengths=(10, 10, 3, 4, 3),
-                                       pad=False)
+
 
 
 def test_get_image_ids(conn, project_structure, screen_structure):
+    
     dataset_info = project_structure[1]
     main_ds_id = dataset_info[0][1]
     image_info = project_structure[2]

--- a/tests/test_ezomero.py
+++ b/tests/test_ezomero.py
@@ -186,6 +186,10 @@ def test_get_image(conn, project_structure):
     assert im_arr.shape == (1, 20, 201, 200, 3)
     assert im.getPixelsType() == im_arr.dtype
 
+    # test cross-group
+
+    # test non-existent id
+
     # test xyzct
     im, im_arr = ezomero.get_image(conn, im_id, xyzct=True)
     assert im_arr.shape == (200, 201, 20, 3, 1)
@@ -236,7 +240,9 @@ def test_get_image_ids(conn, project_structure, screen_structure):
     assert im_ids[0] == im_id1
     assert len(im_ids) == 1
 
-    # Need to add test for orphans
+    # test for orphans
+
+    # test cross-group
 
     # Return nothing on bad input
     im_ids2 = ezomero.get_image_ids(conn, dataset=999999)
@@ -274,6 +280,8 @@ def test_get_group_id(conn):
     gid = ezomero.get_group_id(conn, 'guest')
     assert gid == 2
 
+#def test_get_user_id(conn, whatever)
+
 
 # Test puts
 ###########
@@ -295,3 +303,7 @@ def test_put_map_annotation(conn, project_structure):
                        deleteAnns=True,
                        deleteChildren=True,
                        wait=True)
+
+    # test cross-group
+
+    # test non-existent ID


### PR DESCRIPTION
Added a decorator to relevant functions enabling them to work across groups. Relevant queries are done with group set as `-1` and we re-set things to the correct group before any save operation.