### PR TITLE
Added new ROI types (`Label`, `Polyline`) and extended `Line` to allow start/end markers

### DIFF
--- a/ezomero/_gets.py
+++ b/ezomero/_gets.py
@@ -8,7 +8,7 @@ from omero.model import MapAnnotationI, TagAnnotationI
 from omero.rtypes import rint, rlong
 from omero.sys import Parameters
 from omero.model import enums as omero_enums
-from .rois import Point, Line, Rectangle, Ellipse, Polygon
+from .rois import Point, Line, Rectangle, Ellipse, Polygon, Polyline, Label
 
 
 # gets
@@ -1042,6 +1042,15 @@ def _omero_shape_to_shape(omero_shape):
         text = omero_shape.textValue
     except AttributeError:
         text = None
+    try:
+        mk_start = omero_shape.markerStart
+    except AttributeError:
+        mk_start = None
+    try:
+        mk_end = omero_shape.markerEnd
+    except AttributeError:
+        mk_end = None
+
     if shape_type == "Point":
         x = omero_shape.x
         y = omero_shape.y
@@ -1051,7 +1060,8 @@ def _omero_shape_to_shape(omero_shape):
         x2 = omero_shape.x2
         y1 = omero_shape.y1
         y2 = omero_shape.y2
-        shape = Line(x1, y1, x2, y2, z_val, c_val, t_val, text)
+        shape = Line(x1, y1, x2, y2, z_val, c_val, t_val,
+                     mk_start, mk_end, text)
     elif shape_type == "Rectangle":
         x = omero_shape.x
         y = omero_shape.y
@@ -1071,6 +1081,18 @@ def _omero_shape_to_shape(omero_shape):
             coords = point.split(',')
             points.append((float(coords[0]), float(coords[1])))
         shape = Polygon(points, z_val, c_val, t_val, text)
+    elif shape_type == "Polyline":
+        omero_points = omero_shape.points.split()
+        points = []
+        for point in omero_points:
+            coords = point.split(',')
+            points.append((float(coords[0]), float(coords[1])))
+        shape = Polyline(points, z_val, c_val, t_val, text)
+    elif shape_type == "Label":
+        x = omero_shape.x
+        y = omero_shape.y
+        fsize = omero_shape.getFontSize().getValue()
+        shape = Label(x, y, text, fsize, z_val, c_val, t_val)
     else:
         err = 'The shape passed for the roi is not a valid shape type'
         raise TypeError(err)

--- a/ezomero/_posts.py
+++ b/ezomero/_posts.py
@@ -4,13 +4,13 @@ import numpy as np
 from ._ezomero import do_across_groups, set_group
 from ._misc import link_datasets_to_project
 from omero.model import RoiI, PointI, LineI, RectangleI, EllipseI
-from omero.model import PolygonI, LengthI, enums
+from omero.model import PolygonI, PolylineI, LabelI, LengthI, enums
 from omero.model import DatasetI, ProjectI, ScreenI
 from omero.gateway import ProjectWrapper, DatasetWrapper
 from omero.gateway import ScreenWrapper
 from omero.gateway import MapAnnotationWrapper
 from omero.rtypes import rstring, rint, rdouble
-from .rois import Point, Line, Rectangle, Ellipse, Polygon
+from .rois import Point, Line, Rectangle, Ellipse, Polygon, Polyline, Label
 
 
 def post_dataset(conn, dataset_name, project_id=None, description=None,
@@ -534,6 +534,10 @@ def _shape_to_omero_shape(shape, fill_color, stroke_color, stroke_width):
         omero_shape.x2 = rdouble(shape.x2)
         omero_shape.y1 = rdouble(shape.y1)
         omero_shape.y2 = rdouble(shape.y2)
+        if shape.markerStart is not None:
+            omero_shape.markerStart = rstring(shape.markerStart)
+        if shape.markerEnd is not None:
+            omero_shape.markerEnd = rstring(shape.markerEnd)
     elif isinstance(shape, Rectangle):
         omero_shape = RectangleI()
         omero_shape.x = rdouble(shape.x)
@@ -551,6 +555,17 @@ def _shape_to_omero_shape(shape, fill_color, stroke_color, stroke_width):
         points_str = "".join("".join([str(x), ',', str(y), ', '])
                              for x, y in shape.points)[:-2]
         omero_shape.points = rstring(points_str)
+    elif isinstance(shape, Polyline):
+        omero_shape = PolylineI()
+        points_str = "".join("".join([str(x), ',', str(y), ', '])
+                             for x, y in shape.points)[:-2]
+        omero_shape.points = rstring(points_str)
+    elif isinstance(shape, Label):
+        omero_shape = LabelI()
+        omero_shape.x = rdouble(shape.x)
+        omero_shape.y = rdouble(shape.y)
+        omero_shape.fontSize = LengthI(shape.fontSize,
+                                       enums.UnitsLength.POINT)
     else:
         err = 'The shape passed for the roi is not a valid shape type'
         raise TypeError(err)

--- a/ezomero/rois.py
+++ b/ezomero/rois.py
@@ -5,7 +5,9 @@ __all__ = ["Point",
            "Line",
            "Rectangle",
            "Ellipse",
-           "Polygon"]
+           "Polygon",
+           "Polyline",
+           "Label"]
 
 
 @dataclass(frozen=True)
@@ -76,6 +78,10 @@ class Line:
         The time frame to which the shape is linked.
         If ``None``, the shape will not be linked to any time frame.
         Default is ``None``.
+    markerStart : str, optional
+        The marker for the start of the line. Default is ``None``.
+    markerEnd : str, optional
+        The marker for the end of the line. Default is ``None``.
     label : str, optional
         The label of the shape. Default is ``None``.
     """
@@ -87,6 +93,8 @@ class Line:
     z: int = field(default=None)
     c: int = field(default=None)
     t: int = field(default=None)
+    markerStart: str = field(default=None)
+    markerEnd: str = field(default=None)
     label: str = field(default=None)
 
 
@@ -215,3 +223,81 @@ class Polygon:
     c: int = field(default=None)
     t: int = field(default=None)
     label: str = field(default=None)
+
+
+@dataclass(frozen=True)
+class Polyline:
+    """A dataclass used to create an OMERO polyline.
+
+    A dataclass used to represent a Polyline shape and create an OMERO
+    equivalent. This dataclass is frozen and should not be modified after
+    instantiation.
+
+    Parameters
+    ----------
+    points : list of tuples of 2 floats
+        A list of 2 element tuples corresponding to the (x, y) coordinates of
+        each vertex of the polyline.
+    z : int, optional
+        The z position of the shape in pixels. Note this is the z plane to
+        which the shape is linked and not the sub-voxel resolution position of
+        your shape. If ``None``, the Point will not be linked to any z plane.
+        Default is ``None``.
+    c : int, optional
+        The channel index to which the shape is linked.
+        If None, the shape will not be linked to any channel. Default is
+        ``None``.
+    t : int, optional
+        The time frame to which the shape is linked.
+        If ``None``, the shape will not be linked to any time frame.
+        Default is ``None``.
+    label : str, optional
+        The label of the shape. Default is ``None``.
+    """
+
+    points: List[Tuple[float, float]] = field(metadata={'units': 'PIXELS'})
+    z: int = field(default=None)
+    c: int = field(default=None)
+    t: int = field(default=None)
+    label: str = field(default=None)
+
+
+@dataclass(frozen=True)
+class Label:
+    """A dataclass used to create an OMERO Label.
+
+    A dataclass used to represent a Label shape and create an OMERO equivalent.
+    This dataclass is frozen and should not be modified after instantiation
+
+    Parameters
+    ----------
+    x : float
+        The x axis position of the label shape in pixels.
+    y : float
+        The y axis position of the label shape in pixels.
+    label : str
+        The text value of the Label.
+    fontSize: int
+        The font size of the label, in pt.
+    z : int, optional
+        The z position of the label in pixels. Note this is the z plane to
+        which the shape is linked and not the sub-voxel resolution position of
+        your shape. If ``None``, the Label will not be linked to any z plane.
+        Default is ``None``.
+    c : int, optional
+        The channel index to which the shape is linked.
+        If None, the Label will not be linked to any channel. Default is
+        ``None``.
+    t : int, optional
+        The time frame to which the shape is linked.
+        If ``None``, the Label will not be linked to any time frame.
+        Default is ``None``.
+    """
+
+    x: float = field(metadata={'units': 'PIXELS'})
+    y: float = field(metadata={'units': 'PIXELS'})
+    label: str = field()
+    fontSize: int = field(metadata={'FontSizeUnit': 'pt'})
+    z: int = field(default=None)
+    c: int = field(default=None)
+    t: int = field(default=None)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 omero-py==5.9.2
-numpy==1.18.1
+numpy==1.19.5
 dataclasses

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -194,6 +194,9 @@ def roi_fixture():
     point = rois.Point(x=100.0, y=100.0, z=0, c=0, t=0, label='test_point')
     line = rois.Line(x1=100.0, y1=100.0, x2=150.0, y2=150.0, z=0, c=0, t=0,
                      label='test_line')
+    arrow = rois.Line(x1=100.0, y1=100.0, x2=150.0, y2=150.0, z=0, c=0, t=0,
+                      label='test_arrow', markerEnd="Arrow",
+                      markerStart="Arrow")
     rectangle = rois.Rectangle(x=100.0, y=100.0, width=50.0, height=40.0, z=0,
                                c=0, t=0, label='test_rectangle')
     ellipse = rois.Ellipse(x=80, y=60, x_rad=20.0, y_rad=40.0, z=0, c=0, t=0,
@@ -202,8 +205,15 @@ def roi_fixture():
                                    (110.0, 150.0),
                                    (100.0, 150.0)],
                            z=0, c=0, t=0, label='test_polygon')
+    polyline = rois.Polyline(points=[(100.0, 100.0),
+                                     (110.0, 150.0),
+                                     (100.0, 150.0)],
+                             z=0, c=0, t=0, label='test_polyline')
+    label = rois.Label(x=100.0, y=100.0, z=0, c=0, t=0,
+                       label='test_label', fontSize=60)
 
-    return {'shapes': [point, line, rectangle, ellipse, polygon],
+    return {'shapes': [point, line, rectangle, ellipse,
+                       polygon, polyline, arrow, label],
             'name': 'ROI_name',
             'desc': 'A description for the ROI',
             'fill_color': (255, 0, 0, 200),

--- a/tests/test_rois.py
+++ b/tests/test_rois.py
@@ -1,4 +1,5 @@
 from ezomero.rois import Point, Line, Rectangle, Ellipse, Polygon
+from ezomero.rois import Polyline, Label
 
 
 def test_point_constructor():
@@ -10,6 +11,10 @@ def test_line_constructor():
     line = Line(x1=4.0, y1=5.0, x2=7.0, y2=9.0,
                 z=1, c=0, t=5, label='test_line')
     assert line
+    arrow = Line(x1=2.0, y1=3.0, x2=3.0, y2=4.0,
+                 z=1, c=0, t=5, label='test_arrow',
+                 markerStart="Arrow", markerEnd="Arrow")
+    assert arrow
 
 
 def test_rectangle_constructor():
@@ -28,3 +33,15 @@ def test_polygon_constructor():
     polygon = Polygon(points=[(4.0, 5.0), (14.0, 15.0), (4.0, 15.0)],
                       z=1, c=0, t=5, label='test_polygon')
     assert polygon
+
+
+def test_polyline_constructor():
+    polyline = Polyline(points=[(4.0, 5.0), (14.0, 15.0), (4.0, 15.0)],
+                        z=1, c=0, t=5, label='test_polyline')
+    assert polyline
+
+
+def test_label_constructor():
+    label = Label(x=4.0, y=5.0, z=1, c=0, t=5, label='test_label',
+                  fontSize=60)
+    assert label


### PR DESCRIPTION
## Description

Enhancement aimed at getting [omero-cli-transfer](https://github.com/TheJacksonLaboratory/omero-cli-transfer) to a point where it can transfer all ROIs that can be generated via iViewer.


## Checklist

PEP8 checked, tests cover new functionality, docstrings are in place.

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.

