### PR TITLE
fixing imports with weird chars in path

### DIFF
--- a/.github/workflows/run_tests_pr.yml
+++ b/.github/workflows/run_tests_pr.yml
@@ -8,10 +8,10 @@ jobs:
         uses: actions/checkout@v2
       - name: Run docker compose up
         run: docker-compose -f tests/docker-compose.yml up -d
-      - name: Set up Python 3.6
+      - name: Set up Python 3.7
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.7
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/run_tests_pr.yml
+++ b/.github/workflows/run_tests_pr.yml
@@ -8,7 +8,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Run docker compose up
         run: docker-compose -f tests/docker-compose.yml up -d
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
           python-version: 3.8

--- a/.github/workflows/run_tests_pr.yml
+++ b/.github/workflows/run_tests_pr.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Python 3.7
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/run_tests_push.yml
+++ b/.github/workflows/run_tests_push.yml
@@ -8,10 +8,10 @@ jobs:
         uses: actions/checkout@v2
       - name: Run docker compose up
         run: docker-compose -f tests/docker-compose.yml up -d
-      - name: Set up Python 3.6
+      - name: Set up Python 3.7
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.7
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/run_tests_push.yml
+++ b/.github/workflows/run_tests_push.yml
@@ -8,7 +8,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Run docker compose up
         run: docker-compose -f tests/docker-compose.yml up -d
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
           python-version: 3.8

--- a/.github/workflows/run_tests_push.yml
+++ b/.github/workflows/run_tests_push.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Python 3.7
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/ezomero/_importer.py
+++ b/ezomero/_importer.py
@@ -297,7 +297,7 @@ class Importer:
 
     def make_substitutions(self):
         fpath = self.file_path
-        mytable = fpath.maketrans("\"*:<>?\|", "\'x;[]%/!")
+        mytable = fpath.maketrans("\"*:<>?\\|", "\'x;[]%/!")
         final_path = fpath.translate(mytable)
         return final_path
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 omero-py==5.9.2
-numpy==1.19.5
+numpy>=1.22
 dataclasses

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-omero-py==5.9.2
+omero-py==5.11.2
 numpy>=1.22
 dataclasses


### PR DESCRIPTION
## Description

Fixes #53 and #55. Updates numpy to >=1.22, which means we now require python 3.8. Also updated requirements to the latest omero-py.


## Checklist

Docstring updated, no new tests necessary, passing flake8


## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.

