### PR TITLE
Adding tests to `ezimport`

### DIFF
--- a/.github/workflows/run_tests_pr.yml
+++ b/.github/workflows/run_tests_pr.yml
@@ -8,10 +8,10 @@ jobs:
         uses: actions/checkout@v2
       - name: Run docker compose up
         run: docker-compose -f tests/docker-compose.yml up -d
-      - name: Set up Python 3.6
+      - name: Set up Python 3.7
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.7
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/run_tests_pr.yml
+++ b/.github/workflows/run_tests_pr.yml
@@ -8,7 +8,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Run docker compose up
         run: docker-compose -f tests/docker-compose.yml up -d
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
           python-version: 3.8

--- a/.github/workflows/run_tests_pr.yml
+++ b/.github/workflows/run_tests_pr.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Python 3.7
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/run_tests_push.yml
+++ b/.github/workflows/run_tests_push.yml
@@ -8,10 +8,10 @@ jobs:
         uses: actions/checkout@v2
       - name: Run docker compose up
         run: docker-compose -f tests/docker-compose.yml up -d
-      - name: Set up Python 3.6
+      - name: Set up Python 3.7
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.7
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/run_tests_push.yml
+++ b/.github/workflows/run_tests_push.yml
@@ -8,7 +8,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Run docker compose up
         run: docker-compose -f tests/docker-compose.yml up -d
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
           python-version: 3.8

--- a/.github/workflows/run_tests_push.yml
+++ b/.github/workflows/run_tests_push.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Python 3.7
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A module with convenience functions for writing Python code that interacts with 
 
 # Installation
 
-Just `pip install ezomero` and you should be good to go! The repo contains a `requirements.txt` file with the specific package versions we test `ezomero` with, but any Python>=3.6 and latest `omero-py` and `numpy` _should_ work -  note that this package is in active development!
+Just `pip install ezomero` and you should be good to go! The repo contains a `requirements.txt` file with the specific package versions we test `ezomero` with, but any Python>=3.8 and latest `omero-py` and `numpy` _should_ work -  note that this package is in active development!
 
 # Usage
 

--- a/coverage.svg
+++ b/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">91%</text>
-        <text x="80" y="14">91%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">94%</text>
+        <text x="80" y="14">94%</text>
     </g>
 </svg>

--- a/ezomero/_importer.py
+++ b/ezomero/_importer.py
@@ -297,7 +297,7 @@ class Importer:
 
     def make_substitutions(self):
         fpath = self.file_path
-        mytable = fpath.maketrans("\"*:<>?\|", "\'x;[]%/!")
+        mytable = fpath.maketrans("\"*:<>?\\|", "\'x;[]%/!")
         final_path = fpath.translate(mytable)
         return final_path
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 omero-py==5.9.2
-numpy==1.19.5
+numpy>=1.22
 dataclasses

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-omero-py==5.9.2
+omero-py==5.11.2
 numpy>=1.22
 dataclasses

--- a/tests/test_ezimport.py
+++ b/tests/test_ezimport.py
@@ -1,62 +1,116 @@
-# import ezomero
-# import pytest
-
-
-# This file is a placeholder for the tests we would LIKE to run
-# (if running any tests that involve CLI was easier)
+import ezomero
+from io import StringIO
 
 # Test imports
 
 
-# def test_ezimport(self, conn):
+def test_ezimport(conn, monkeypatch):
 
-#     # test simple import, single file
-#     id = ezomero.ezimport(conn, "tests/data/test_pyramid.ome.tif")
-#     assert len(id) == 1
+    # test simple import, single file
+    fpath = "tests/data/test_pyramid.ome.tif"
+    str_input = ["omero", 'import',
+                 '-k', conn.getSession().getUuid().val,
+                 '-s', conn.host,
+                 '-p', str(conn.port),
+                 fpath, "\n"]
+    io = StringIO(" ".join(str_input))
+    monkeypatch.setattr('sys.stdin', io)
+    id = ezomero.ezimport(conn, fpath)
+    assert len(id) == 1
+    conn.deleteObjects("Image", id)
 
 #     # test simple import, multifile/multi-image
-#     id = ezomero.ezimport(conn, "tests/data/vsi-ets-test-jpg2k.vsi")
-#     assert len(id) == 2
+    fpath = "tests/data/vsi-ets-test-jpg2k.vsi"
+    str_input = ["omero", 'import',
+                 '-k', conn.getSession().getUuid().val,
+                 '-s', conn.host,
+                 '-p', str(conn.port),
+                 fpath, "\n"]
+    io = StringIO(" ".join(str_input))
+    monkeypatch.setattr('sys.stdin', io)
+    id = ezomero.ezimport(conn, fpath)
+    assert len(id) == 2
 
 #     # test simple import, new orphan dataset
-#     id = ezomero.ezimport(conn, "tests/data/test_pyramid.ome.tif",
-#                             dataset="test_ds")
-#     assert len(id) == 1
-#     ds_id = ezomero.get_dataset_ids(conn)[-1]
-#     im_ids = ezomero.get_image_ids(conn, dataset=ds_id)
-#     assert len(im_ids) == 1
-#     assert im_ids[0] == id
+    fpath = "tests/data/test_pyramid.ome.tif"
+    str_input = ["omero", 'import',
+                 '-k', conn.getSession().getUuid().val,
+                 '-s', conn.host,
+                 '-p', str(conn.port),
+                 fpath, "\n"]
+    io = StringIO(" ".join(str_input))
+    monkeypatch.setattr('sys.stdin', io)
+    id = ezomero.ezimport(conn, fpath, dataset="test_ds")
+    assert len(id) == 1
+    ds_id = ezomero.get_dataset_ids(conn)[-1]
+    im_ids = ezomero.get_image_ids(conn, dataset=ds_id)
+    assert len(im_ids) == 1
+    assert im_ids[0] == id[-1]
 
 #     # test simple import, existing dataset
-#     id = ezomero.ezimport(conn, "tests/data/test_pyramid.ome.tif",
-#                             dataset=ds_id)
-#     im_ids = ezomero.get_image_ids(conn, dataset=ds_id)
-#     assert len(im_ids) == 2
-#     assert im_ids[-1] == id
+    fpath = "tests/data/test_pyramid.ome.tif"
+    str_input = ["omero", 'import',
+                 '-k', conn.getSession().getUuid().val,
+                 '-s', conn.host,
+                 '-p', str(conn.port),
+                 fpath, "\n"]
+    io = StringIO(" ".join(str_input))
+    monkeypatch.setattr('sys.stdin', io)
+    id = ezomero.ezimport(conn, fpath, dataset=ds_id)
+    im_ids = ezomero.get_image_ids(conn, dataset=ds_id)
+    assert len(im_ids) == 2
+    assert im_ids[-1] == id[-1]
+    conn.deleteObjects("Dataset", [ds_id], deleteChildren=True)
 
 #     # test simple import, new project
-#     id = ezomero.ezimport(conn, "tests/data/test_pyramid.ome.tif",
-#                             project="test_proj", dataset="test_ds")
-#     assert len(id) == 1
-#     proj_id = ezomero.get_project_ids(conn)[-1]
-#     ds_id = ezomero.get_dataset_ids(conn, project=proj_id)[-1]
-#     im_ids = ezomero.get_image_ids(conn, dataset=ds_id)
-#     assert len(im_ids) == 1
-#     assert im_ids[0] == id
+    fpath = "tests/data/test_pyramid.ome.tif"
+    str_input = ["omero", 'import',
+                 '-k', conn.getSession().getUuid().val,
+                 '-s', conn.host,
+                 '-p', str(conn.port),
+                 fpath, "\n"]
+    io = StringIO(" ".join(str_input))
+    monkeypatch.setattr('sys.stdin', io)
+    id = ezomero.ezimport(conn, fpath,
+                          project="test_proj", dataset="test_ds")
+    assert len(id) == 1
+    proj_id = ezomero.get_project_ids(conn)[-1]
+    ds_id = ezomero.get_dataset_ids(conn, project=proj_id)[-1]
+    im_ids = ezomero.get_image_ids(conn, dataset=ds_id)
+    assert len(im_ids) == 1
+    assert im_ids[0] == id[-1]
 
 #     # test simple import, existing project, new dataset
-#     id = ezomero.ezimport(conn, "tests/data/test_pyramid.ome.tif",
-#                             project=proj_id, dataset="new_test_ds")
-#     ds_ids = ezomero.get_dataset_ids(conn, project=proj_id)
-#     im_ids = ezomero.get_image_ids(conn, dataset=ds_ids[-1])
-#     assert len(ds_ids) == 2
-#     assert len(im_ids) == 1
-#     assert im_ids[0] == id
+    fpath = "tests/data/test_pyramid.ome.tif"
+    str_input = ["omero", 'import',
+                 '-k', conn.getSession().getUuid().val,
+                 '-s', conn.host,
+                 '-p', str(conn.port),
+                 fpath, "\n"]
+    io = StringIO(" ".join(str_input))
+    monkeypatch.setattr('sys.stdin', io)
+    id = ezomero.ezimport(conn, fpath,
+                          project=proj_id, dataset="new_test_ds")
+    ds_ids = ezomero.get_dataset_ids(conn, project=proj_id)
+    im_ids = ezomero.get_image_ids(conn, dataset=ds_ids[-1])
+    assert len(ds_ids) == 2
+    assert len(im_ids) == 1
+    assert im_ids[0] == id[-1]
 
 #     # test simple import, existing project, existing dataset
-#     id = ezomero.ezimport(conn, "tests/data/test_pyramid.ome.tif",
-#                             project=proj_id, dataset=ds_id)
-#     ds_id = ezomero.get_dataset_ids(conn, project=proj_id)[-1]
-#     im_ids = ezomero.get_image_ids(conn, dataset=ds_id)
-#     assert len(im_ids) == 2
-#     assert im_ids[-1] == id
+    fpath = "tests/data/test_pyramid.ome.tif"
+    str_input = ["omero", 'import',
+                 '-k', conn.getSession().getUuid().val,
+                 '-s', conn.host,
+                 '-p', str(conn.port),
+                 fpath, "\n"]
+    io = StringIO(" ".join(str_input))
+    monkeypatch.setattr('sys.stdin', io)
+    id = ezomero.ezimport(conn, fpath,
+                          project=proj_id, dataset=ds_id)
+    ds_id = ezomero.get_dataset_ids(conn, project=proj_id)[0]
+    im_ids = ezomero.get_image_ids(conn, dataset=ds_id)
+    assert len(im_ids) == 2
+    assert im_ids[-1] == id[-1]
+
+    conn.deleteObjects("Project", [proj_id], deleteChildren=True)


### PR DESCRIPTION
## Description

This PR adds tests to `ezomero.ezimport`. Note that `--ln_s` imports are not being tested.


## Checklist

New unit tests, flake8 checked.

<!-- For detailed information on these and other aspects see -->
<!-- the ezomero contribution guidelines. -->
<!-- https://github.com/TheJacksonLaboratory/ezomero/CONTRIBUTING.md -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.

