### PR TITLE
defaults for shape colors and width (plus cleanup)

### DIFF
--- a/ezomero/_ezomero.py
+++ b/ezomero/_ezomero.py
@@ -258,18 +258,27 @@ def connect(user: Optional[str] = None, password: Optional[str] = None,
         host = input('Enter host: ')
 
     # set port
+    port_str = None
     if port is None:
         if config_dict:
-            port = config_dict.getint("OMERO_PORT", port)
-        port = int(os.environ.get("OMERO_PORT", str(port)))
+            port_str = config_dict.get("OMERO_PORT", str(port))
+        port_str = os.environ.get("OMERO_PORT", port_str)
+        if port_str:
+            port = int(port_str)
     if port is None:
         port = int(input('Enter port: '))
 
     # set session security
+    secure_str = None
     if secure is None:
         if config_dict:
-            secure = config_dict.getboolean("OMERO_SECURE", secure)
-        secure = bool(os.environ.get("OMERO_SECURE", str(secure)))
+            secure_str = config_dict.get("OMERO_SECURE", str(secure))
+    secure_str = os.environ.get("OMERO_SECURE", secure_str)
+    if secure_str:
+        if secure_str.lower() in ["true", "t"]:
+            secure = True
+        elif secure_str.lower() in ["false", "f"]:
+            secure = False
     if secure is None:
         str_secure: str = input('Secure session (True or False): ')
         if str_secure.lower() in ["true", "t"]:
@@ -278,7 +287,6 @@ def connect(user: Optional[str] = None, password: Optional[str] = None,
             secure = False
         else:
             raise ValueError('secure must be set to either True or False')
-
     # create connection
     conn = BlitzGateway(user, password, group=group, host=host, port=port,
                         secure=secure)

--- a/ezomero/_importer.py
+++ b/ezomero/_importer.py
@@ -62,7 +62,7 @@ def ezimport(conn: BlitzGateway, target: str,
         return imp_ctl.plate_ids
 
     else:
-        imp_ctl.get_image_ids()
+        imp_ctl.get_my_image_ids()
         imp_ctl.organize_images()
         imp_ctl.annotate_images()
         return imp_ctl.image_ids
@@ -279,7 +279,7 @@ class Importer:
         self.ann = ann
         self.ns = ns
 
-    def get_image_ids(self) -> Union[List[int], None]:
+    def get_my_image_ids(self) -> Union[List[int], None]:
         """Get the Ids of imported images.
 
         Note that this will not find images if they have not been imported.

--- a/ezomero/_posts.py
+++ b/ezomero/_posts.py
@@ -1,6 +1,6 @@
 import logging
 import mimetypes
-from typing import Optional, List, Union, Tuple
+from typing import Optional, List, Union, Tuple, Any
 import numpy as np
 from uuid import uuid4
 from ._ezomero import do_across_groups, set_group
@@ -16,9 +16,9 @@ from omero.gateway import ScreenWrapper, FileAnnotationWrapper
 from omero.gateway import MapAnnotationWrapper, OriginalFileWrapper
 from omero.rtypes import rstring, rint, rdouble
 from .rois import Point, Line, Rectangle, Ellipse
-from .rois import Polygon, Polyline, Label, ezShape
+from .rois import Polygon, Polyline, Label
 import importlib.util
-# try importing pandas
+
 if (importlib.util.find_spec('pandas')):
     import pandas as pd
     has_pandas = True
@@ -553,13 +553,7 @@ def post_roi(conn: BlitzGateway, image_id: int,
     return roi.getId().getValue()
 
 
-if has_pandas:
-    TableType = pd.core.frame.DataFrame
-else:
-    TableType = List
-
-
-def post_table(conn: BlitzGateway, table: TableType,
+def post_table(conn: BlitzGateway, table: Any,
                object_type: str, object_id: int,
                title: Optional[str] = "",
                headers: bool = True) -> Union[int, None]:
@@ -643,7 +637,7 @@ def post_table(conn: BlitzGateway, table: TableType,
     return file_ann.id
 
 
-def create_columns(table: TableType,
+def create_columns(table: Any,
                    headers: bool) -> List[Column]:
     """Helper function to create the correct column types from a table"""
     cols = []

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -24,7 +24,6 @@ def test_connect_params(omero_params, tmp_path, monkeypatch):
                 "omero_secure = True\n")
     conf_path = tmp_path / '.ezomero'
     conf_path.write_text(conf_txt)
-
     conn = ezomero.connect(user, password, host=host, group='', port=port,
                            secure=True, config_path=str(tmp_path))
     assert conn.getUser().getName() == user


### PR DESCRIPTION
- Added defaults for `Shape`s that don't have `fill/strokecolor` and `strokewidth` (#63)
- gave up on correctly typing the optional pandas import (tables now have `Any` type)
- removed an ambiguous name overlap in importer
- fixed indentation on docstring (#62)

## Description

Should close #62 and #63.


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the ezomero contribution guidelines. -->
<!-- https://github.com/TheJacksonLaboratory/ezomero/CONTRIBUTING.md -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.

