### PR TITLE
moving `fill_color`, `stroke_color` and `stroke_width` to be `Shape` attributes

### DIFF
--- a/ezomero/_posts.py
+++ b/ezomero/_posts.py
@@ -463,12 +463,8 @@ def post_screen(conn: BlitzGateway, screen_name: str,
 def post_roi(conn: BlitzGateway, image_id: int,
              shapes: List[Union[Point, Line, Rectangle, Ellipse,
                                 Polygon, Polyline, Label]],
-             name: Optional[str] = None, description: Optional[str] = None,
-             fill_color: Optional[Union[Tuple[int, int, int, int], int]] =
-             (10, 10, 10, 10),
-             stroke_color: Optional[Union[Tuple[int, int, int, int], int]] =
-             (255, 255, 255, 255),
-             stroke_width: Optional[int] = 1) -> int:
+             name: Optional[str] = None, description: Optional[str] = None)\
+                -> int:
     """Create new ROI from a list of shapes and link to an image.
 
     Parameters
@@ -483,17 +479,6 @@ def post_roi(conn: BlitzGateway, image_id: int,
         Name for the new ROI.
     description : str, optional
         Description of the new ROI.
-    fill_color: tuple of int, optional
-        The color fill of the shape. Color is specified as a a tuple containing
-        4 integers from 0 to 255, representing red, green, blue and alpha
-        levels. Default is (10, 10, 10, 10).
-    stroke_color: tuple of int, optional
-        The color of the shape edge. Color is specified as a a tuple containing
-        4 integers from 0 to 255, representing red, green, blue and alpha
-        levels. Default is (255, 255, 255, 255).
-    stroke_width: int, optional
-        The width of the shape stroke in pixels. Default is 1.
-
 
     Returns
     -------
@@ -510,13 +495,13 @@ def post_roi(conn: BlitzGateway, image_id: int,
                               width=90,
                               height=40,
                               z=3,
-                              label='The place')
+                              label='The place',
+                              fill_color=(255, 10, 10, 150),
+                              stroke_color=(255, 0, 0, 0),
+                              stroke_width=2)
     >>> shapes.append(rectangle)
     >>> post_roi(conn, 23, shapes, name='My Cell',
-                 description='Very important',
-                 fill_color=(255, 10, 10, 150),
-                 stroke_color=(255, 0, 0, 0),
-                 stroke_width=2)
+                 description='Very important')
     234
     """
 
@@ -526,27 +511,13 @@ def post_roi(conn: BlitzGateway, image_id: int,
     if not isinstance(shapes, list):
         raise TypeError('Shapes must be a list')
 
-    if not isinstance(fill_color, tuple):
-        raise TypeError('Fill color must be a tuple')
-    if len(fill_color) != 4:
-        raise ValueError('Fill color must contain 4 integers')
-
-    if not isinstance(stroke_color, tuple):
-        raise TypeError('Stroke color must be a tuple')
-    if len(stroke_color) != 4:
-        raise ValueError('Stroke color must contain 4 integers')
-
-    if type(stroke_width) is not int:
-        raise TypeError('Stroke width must be an integer')
-
     roi = RoiI()
     if name is not None:
         roi.setName(rstring(name))
     if description is not None:
         roi.setDescription(rstring(description))
     for shape in shapes:
-        roi.addShape(_shape_to_omero_shape(shape, fill_color, stroke_color,
-                                           stroke_width))
+        roi.addShape(_shape_to_omero_shape(shape))
     image = conn.getObject('Image', image_id)
     roi.setImage(image._obj)
     roi = conn.getUpdateService().saveAndReturnObject(roi)
@@ -687,10 +658,7 @@ def create_columns(table: Any,
 
 
 def _shape_to_omero_shape(shape: Union[Point, Line, Rectangle, Ellipse,
-                                       Polygon, Polyline, Label],
-                          fill_color: Tuple[int, int, int, int],
-                          stroke_color: Tuple[int, int, int, int],
-                          stroke_width: int) -> Shape:
+                                       Polygon, Polyline, Label]) -> Shape:
     """ Helper function to convert ezomero shapes into omero shapes"""
     if isinstance(shape, Point):
         omero_shape = PointI()
@@ -746,14 +714,23 @@ def _shape_to_omero_shape(shape: Union[Point, Line, Rectangle, Ellipse,
         omero_shape.theT = rint(shape.t)
     if shape.label is not None:
         omero_shape.setTextValue(rstring(shape.label))
-    omero_shape.setFillColor(rint(_rgba_to_int(fill_color)))
-    omero_shape.setStrokeColor(rint(_rgba_to_int(stroke_color)))
-    omero_shape.setStrokeWidth(LengthI(stroke_width, enums.UnitsLength.PIXEL))
-
+    if shape.fill_color is not None:
+        omero_shape.setFillColor(rint(_rgba_to_int(shape.fill_color)))
+    else:
+        omero_shape.setFillColor(rint(_rgba_to_int((0, 0, 0, 0))))
+    if shape.stroke_color is not None:
+        omero_shape.setStrokeColor(rint(_rgba_to_int(shape.stroke_color)))
+    else:
+        omero_shape.setFillColor(rint(_rgba_to_int((255, 255, 0, 255))))
+    if shape.stroke_width is not None:
+        omero_shape.setStrokeWidth(LengthI(shape.stroke_width,
+                                           enums.UnitsLength.PIXEL))
+    else:
+        omero_shape.setStrokeWidth(LengthI(1.0, enums.UnitsLength.PIXEL))
     return omero_shape
 
 
-def _rgba_to_int(color: Tuple[int, int, int, int]) -> int:
+def _rgba_to_int(color: Tuple[int, ...]) -> int:
     """ Helper function returning the color as an Integer in RGBA encoding """
     try:
         r, g, b, a = color

--- a/ezomero/rois.py
+++ b/ezomero/rois.py
@@ -50,6 +50,22 @@ class Point(ezShape):
         Default is ``None``.
     label : str, optional
         The label of the shape. Default is ``None``.
+    fill_color : Tuple (4 integers), optional
+        The color that will be used as the fill/background of this Shape.
+        Format is RGBA, 0-255.
+        If ``None``, we default to (0, 0, 0, 0) (i.e. transparent) in
+        ``ezomero.get_shape()``.
+        Default is ``None``.
+    stroke_color : Tuple (4 integers), optional
+        The color that will be used as the stroke/perimeter of this Shape.
+        Format is RGBA, 0-255.
+        If ``None``, we default to (255, 255, 0, 255) (i.e. yellow, following
+        OMERO.iViewer default) in ``ezomero.get_shape()``.
+        Default is ``None``.
+    stroke_width : float, optional
+        The line width used for the stroke/perimeter of this Shape.
+        If ``None``, we default to 1.0 in ``ezomero.get_shape()``.
+        Default is ``None``.
     """
 
     x: float = field(metadata={'units': 'PIXELS'})
@@ -58,6 +74,9 @@ class Point(ezShape):
     c: Union[int, None] = field(default=None)
     t: Union[int, None] = field(default=None)
     label: Union[str, None] = field(default=None)
+    fill_color: Union[Tuple[int, int, int, int], None] = field(default=None)
+    stroke_color: Union[Tuple[int, int, int, int], None] = field(default=None)
+    stroke_width: Union[float, None] = field(default=None)
 
 
 @dataclass(frozen=True)
@@ -96,6 +115,22 @@ class Line(ezShape):
         The marker for the end of the line. Default is ``None``.
     label : str, optional
         The label of the shape. Default is ``None``.
+    fill_color : Tuple (4 integers), optional
+        The color that will be used as the fill/background of this Shape.
+        Format is RGBA, 0-255.
+        If ``None``, we default to (0, 0, 0, 0) (i.e. transparent) in
+        ``ezomero.get_shape()``.
+        Default is ``None``.
+    stroke_color : Tuple (4 integers), optional
+        The color that will be used as the stroke/perimeter of this Shape.
+        Format is RGBA, 0-255.
+        If ``None``, we default to (255, 255, 0, 255) (i.e. yellow, following
+        OMERO.iViewer default) in ``ezomero.get_shape()``.
+        Default is ``None``.
+    stroke_width : float, optional
+        The line width used for the stroke/perimeter of this Shape.
+        If ``None``, we default to 1.0 in ``ezomero.get_shape()``.
+        Default is ``None``.
     """
 
     x1: float = field(metadata={'units': 'PIXELS'})
@@ -108,6 +143,9 @@ class Line(ezShape):
     markerStart: Union[str, None] = field(default=None)
     markerEnd: Union[str, None] = field(default=None)
     label: Union[str, None] = field(default=None)
+    fill_color: Union[Tuple[int, int, int, int], None] = field(default=None)
+    stroke_color: Union[Tuple[int, int, int, int], None] = field(default=None)
+    stroke_width: Union[float, None] = field(default=None)
 
 
 @dataclass(frozen=True)
@@ -143,6 +181,22 @@ class Rectangle(ezShape):
         Default is ``None``.
     label : str, optional
         The label of the shape. Default is ``None``.
+    fill_color : Tuple (4 integers), optional
+        The color that will be used as the fill/background of this Shape.
+        Format is RGBA, 0-255.
+        If ``None``, we default to (0, 0, 0, 0) (i.e. transparent) in
+        ``ezomero.get_shape()``.
+        Default is ``None``.
+    stroke_color : Tuple (4 integers), optional
+        The color that will be used as the stroke/perimeter of this Shape.
+        Format is RGBA, 0-255.
+        If ``None``, we default to (255, 255, 0, 255) (i.e. yellow, following
+        OMERO.iViewer default) in ``ezomero.get_shape()``.
+        Default is ``None``.
+    stroke_width : float, optional
+        The line width used for the stroke/perimeter of this Shape.
+        If ``None``, we default to 1.0 in ``ezomero.get_shape()``.
+        Default is ``None``.
     """
 
     x: float = field(metadata={'units': 'PIXELS'})
@@ -153,6 +207,9 @@ class Rectangle(ezShape):
     c: Union[int, None] = field(default=None)
     t: Union[int, None] = field(default=None)
     label: Union[str, None] = field(default=None)
+    fill_color: Union[Tuple[int, int, int, int], None] = field(default=None)
+    stroke_color: Union[Tuple[int, int, int, int], None] = field(default=None)
+    stroke_width: Union[float, None] = field(default=None)
 
 
 @dataclass(frozen=True)
@@ -188,6 +245,22 @@ class Ellipse(ezShape):
         Default is ``None``.
     label : str, optional
         The label of the shape. Default is ``None``.
+    fill_color : Tuple (4 integers), optional
+        The color that will be used as the fill/background of this Shape.
+        Format is RGBA, 0-255.
+        If ``None``, we default to (0, 0, 0, 0) (i.e. transparent) in
+        ``ezomero.get_shape()``.
+        Default is ``None``.
+    stroke_color : Tuple (4 integers), optional
+        The color that will be used as the stroke/perimeter of this Shape.
+        Format is RGBA, 0-255.
+        If ``None``, we default to (255, 255, 0, 255) (i.e. yellow, following
+        OMERO.iViewer default) in ``ezomero.get_shape()``.
+        Default is ``None``.
+    stroke_width : float, optional
+        The line width used for the stroke/perimeter of this Shape.
+        If ``None``, we default to 1.0 in ``ezomero.get_shape()``.
+        Default is ``None``.
     """
 
     x: float = field(metadata={'units': 'PIXELS'})
@@ -198,6 +271,9 @@ class Ellipse(ezShape):
     c: Union[int, None] = field(default=None)
     t: Union[int, None] = field(default=None)
     label: Union[str, None] = field(default=None)
+    fill_color: Union[Tuple[int, int, int, int], None] = field(default=None)
+    stroke_color: Union[Tuple[int, int, int, int], None] = field(default=None)
+    stroke_width: Union[float, None] = field(default=None)
 
 
 @dataclass(frozen=True)
@@ -228,6 +304,22 @@ class Polygon(ezShape):
         Default is ``None``.
     label : str, optional
         The label of the shape. Default is ``None``.
+    fill_color : Tuple (4 integers), optional
+        The color that will be used as the fill/background of this Shape.
+        Format is RGBA, 0-255.
+        If ``None``, we default to (0, 0, 0, 0) (i.e. transparent) in
+        ``ezomero.get_shape()``.
+        Default is ``None``.
+    stroke_color : Tuple (4 integers), optional
+        The color that will be used as the stroke/perimeter of this Shape.
+        Format is RGBA, 0-255.
+        If ``None``, we default to (255, 255, 0, 255) (i.e. yellow, following
+        OMERO.iViewer default) in ``ezomero.get_shape()``.
+        Default is ``None``.
+    stroke_width : float, optional
+        The line width used for the stroke/perimeter of this Shape.
+        If ``None``, we default to 1.0 in ``ezomero.get_shape()``.
+        Default is ``None``.
     """
 
     points: List[Tuple[float, float]] = field(metadata={'units': 'PIXELS'})
@@ -235,6 +327,9 @@ class Polygon(ezShape):
     c: Union[int, None] = field(default=None)
     t: Union[int, None] = field(default=None)
     label: Union[str, None] = field(default=None)
+    fill_color: Union[Tuple[int, int, int, int], None] = field(default=None)
+    stroke_color: Union[Tuple[int, int, int, int], None] = field(default=None)
+    stroke_width: Union[float, None] = field(default=None)
 
 
 @dataclass(frozen=True)
@@ -265,6 +360,22 @@ class Polyline(ezShape):
         Default is ``None``.
     label : str, optional
         The label of the shape. Default is ``None``.
+    fill_color : Tuple (4 integers), optional
+        The color that will be used as the fill/background of this Shape.
+        Format is RGBA, 0-255.
+        If ``None``, we default to (0, 0, 0, 0) (i.e. transparent) in
+        ``ezomero.get_shape()``.
+        Default is ``None``.
+    stroke_color : Tuple (4 integers), optional
+        The color that will be used as the stroke/perimeter of this Shape.
+        Format is RGBA, 0-255.
+        If ``None``, we default to (255, 255, 0, 255) (i.e. yellow, following
+        OMERO.iViewer default) in ``ezomero.get_shape()``.
+        Default is ``None``.
+    stroke_width : float, optional
+        The line width used for the stroke/perimeter of this Shape.
+        If ``None``, we default to 1.0 in ``ezomero.get_shape()``.
+        Default is ``None``.
     """
 
     points: List[Tuple[float, float]] = field(metadata={'units': 'PIXELS'})
@@ -272,6 +383,9 @@ class Polyline(ezShape):
     c: Union[int, None] = field(default=None)
     t: Union[int, None] = field(default=None)
     label: Union[str, None] = field(default=None)
+    fill_color: Union[Tuple[int, int, int, int], None] = field(default=None)
+    stroke_color: Union[Tuple[int, int, int, int], None] = field(default=None)
+    stroke_width: Union[float, None] = field(default=None)
 
 
 @dataclass(frozen=True)
@@ -304,6 +418,22 @@ class Label(ezShape):
         The time frame to which the shape is linked.
         If ``None``, the Label will not be linked to any time frame.
         Default is ``None``.
+    fill_color : Tuple (4 integers), optional
+        The color that will be used as the fill/background of this Shape.
+        Format is RGBA, 0-255.
+        If ``None``, we default to (0, 0, 0, 0) (i.e. transparent) in
+        ``ezomero.get_shape()``.
+        Default is ``None``.
+    stroke_color : Tuple (4 integers), optional
+        The color that will be used as the stroke/perimeter of this Shape.
+        Format is RGBA, 0-255.
+        If ``None``, we default to (255, 255, 0, 255) (i.e. yellow, following
+        OMERO.iViewer default) in ``ezomero.get_shape()``.
+        Default is ``None``.
+    stroke_width : float, optional
+        The line width used for the stroke/perimeter of this Shape.
+        If ``None``, we default to 1.0 in ``ezomero.get_shape()``.
+        Default is ``None``.
     """
 
     x: float = field(metadata={'units': 'PIXELS'})
@@ -313,3 +443,6 @@ class Label(ezShape):
     z: Union[int, None] = field(default=None)
     c: Union[int, None] = field(default=None)
     t: Union[int, None] = field(default=None)
+    fill_color: Union[Tuple[int, int, int, int], None] = field(default=None)
+    stroke_color: Union[Tuple[int, int, int, int], None] = field(default=None)
+    stroke_width: Union[float, None] = field(default=None)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -198,34 +198,49 @@ def pyramid_fixture(conn, omero_params):
 
 @pytest.fixture(scope='session')
 def roi_fixture():
-    point = rois.Point(x=100.0, y=100.0, z=0, c=0, t=0, label='test_point')
+    point = rois.Point(x=100.0, y=100.0, z=0, c=0, t=0, label='test_point',
+                       fill_color=(0, 1, 2, 3), stroke_color=(4, 5, 6, 100),
+                       stroke_width=1.0)
     line = rois.Line(x1=100.0, y1=100.0, x2=150.0, y2=150.0, z=0, c=0, t=0,
-                     label='test_line')
+                     label='test_line', fill_color=(7, 8, 9, 10),
+                     stroke_color=(11, 12, 13, 106), stroke_width=2.0)
     arrow = rois.Line(x1=100.0, y1=100.0, x2=150.0, y2=150.0, z=0, c=0, t=0,
                       label='test_arrow', markerEnd="Arrow",
                       markerStart="Arrow")
     rectangle = rois.Rectangle(x=100.0, y=100.0, width=50.0, height=40.0, z=0,
-                               c=0, t=0, label='test_rectangle')
+                               c=0, t=0, label='test_rectangle',
+                               fill_color=(14, 15, 16, 17),
+                               stroke_color=(18, 19, 20, 101),
+                               stroke_width=3.0)
     ellipse = rois.Ellipse(x=80, y=60, x_rad=20.0, y_rad=40.0, z=0, c=0, t=0,
-                           label='test_ellipse')
+                           label='test_ellipse',
+                           fill_color=(21, 22, 23, 24),
+                           stroke_color=(25, 26, 27, 102),
+                           stroke_width=4.0)
     polygon = rois.Polygon(points=[(100.0, 100.0),
                                    (110.0, 150.0),
                                    (100.0, 150.0)],
-                           z=0, c=0, t=0, label='test_polygon')
+                           z=0, c=0, t=0, label='test_polygon',
+                           fill_color=(28, 29, 30, 31),
+                           stroke_color=(32, 33, 34, 103),
+                           stroke_width=5.0)
     polyline = rois.Polyline(points=[(100.0, 100.0),
                                      (110.0, 150.0),
                                      (100.0, 150.0)],
-                             z=0, c=0, t=0, label='test_polyline')
+                             z=0, c=0, t=0, label='test_polyline',
+                             fill_color=(35, 36, 37, 38),
+                             stroke_color=(39, 40, 41, 104),
+                             stroke_width=6.0)
     label = rois.Label(x=100.0, y=100.0, z=0, c=0, t=0,
-                       label='test_label', fontSize=60)
+                       label='test_label', fontSize=60,
+                       fill_color=(42, 43, 44, 45),
+                       stroke_color=(46, 47, 48, 105),
+                       stroke_width=7.0)
 
     return {'shapes': [point, line, rectangle, ellipse,
                        polygon, polyline, arrow, label],
             'name': 'ROI_name',
-            'desc': 'A description for the ROI',
-            'fill_color': (255, 0, 0, 200),
-            'stroke_color': (255, 0, 0, 0),
-            'stroke_width': 2
+            'desc': 'A description for the ROI'
             }
 
 

--- a/tests/test_gets.py
+++ b/tests/test_gets.py
@@ -452,10 +452,7 @@ def test_get_roi_ids(conn, project_structure, roi_fixture, users_groups):
     roi_id = ezomero.post_roi(conn, im_id,
                               shapes=roi_fixture['shapes'],
                               name=roi_fixture['name'],
-                              description=roi_fixture['desc'],
-                              fill_color=roi_fixture['fill_color'],
-                              stroke_color=roi_fixture['stroke_color'],
-                              stroke_width=roi_fixture['stroke_width'])
+                              description=roi_fixture['desc'])
     return_ids = ezomero.get_roi_ids(conn, im_id)
     assert roi_id in return_ids
 
@@ -486,22 +483,30 @@ def test_get_shape_and_get_shape_ids(conn, project_structure,
     # test normal usage
     image_info = project_structure[2]
     im_id = image_info[0][1]
+    shapes = roi_fixture['shapes']
+    arrow = shapes.pop(6)
     roi_id = ezomero.post_roi(conn, im_id,
-                              shapes=roi_fixture['shapes'],
+                              shapes=shapes,
                               name=roi_fixture['name'],
-                              description=roi_fixture['desc'],
-                              fill_color=roi_fixture['fill_color'],
-                              stroke_color=roi_fixture['stroke_color'],
-                              stroke_width=roi_fixture['stroke_width'])
+                              description=roi_fixture['desc'])
     shape_ids = ezomero.get_shape_ids(conn, roi_id)
     assert len(shape_ids) == len(roi_fixture['shapes'])
     for i in range(len(shape_ids)):
-        shape, fill, stroke, width = ezomero.get_shape(conn, shape_ids[i])
+        shape = ezomero.get_shape(conn, shape_ids[i])
         assert hasattr(shape, 'label')
-        assert fill == roi_fixture['fill_color']
-        assert stroke == roi_fixture['stroke_color']
-        assert width == roi_fixture['stroke_width']
-
+        for pre_shape in shapes:
+            if type(shape) == type(pre_shape):
+                assert shape.fill_color == pre_shape.fill_color
+                assert shape.stroke_color == pre_shape.stroke_color
+                assert shape.stroke_width == pre_shape.stroke_width
+    roi_id2 = ezomero.post_roi(conn, im_id,
+                               shapes=[arrow],
+                               name=roi_fixture['name'],
+                               description=roi_fixture['desc'])
+    shape_ids2 = ezomero.get_shape_ids(conn, roi_id2)
+    assert len(shape_ids2) == 1
+    shape = ezomero.get_shape(conn, shape_ids2[0])
+    assert shape.markerStart == "Arrow"
     # Test getting from an invalid cross-group
     username = users_groups[1][2][0]  # test_user3
     groupname = users_groups[0][1][0]  # test_group_2

--- a/tests/test_posts.py
+++ b/tests/test_posts.py
@@ -316,74 +316,22 @@ def test_post_roi(conn, project_structure, roi_fixture, users_groups):
         _ = ezomero.post_roi(conn, '10',
                              shapes=roi_fixture['shapes'],
                              name=roi_fixture['name'],
-                             description=roi_fixture['desc'],
-                             fill_color=roi_fixture['fill_color'],
-                             stroke_color=roi_fixture['stroke_color'],
-                             stroke_width=roi_fixture['stroke_width'])
+                             description=roi_fixture['desc'])
     with pytest.raises(TypeError):
         _ = ezomero.post_roi(conn, im_id,
                              shapes='10',
                              name=roi_fixture['name'],
-                             description=roi_fixture['desc'],
-                             fill_color=roi_fixture['fill_color'],
-                             stroke_color=roi_fixture['stroke_color'],
-                             stroke_width=roi_fixture['stroke_width'])
+                             description=roi_fixture['desc'])
     with pytest.raises(TypeError):
         _ = ezomero.post_roi(conn, im_id,
                              shapes=['10'],
                              name=roi_fixture['name'],
-                             description=roi_fixture['desc'],
-                             fill_color=roi_fixture['fill_color'],
-                             stroke_color=roi_fixture['stroke_color'],
-                             stroke_width=roi_fixture['stroke_width'])
-    with pytest.raises(TypeError):
-        _ = ezomero.post_roi(conn, im_id,
-                             shapes=roi_fixture['shapes'],
-                             name=roi_fixture['name'],
-                             description=roi_fixture['desc'],
-                             fill_color=[10, 10, 10, 10],
-                             stroke_color=roi_fixture['stroke_color'],
-                             stroke_width=roi_fixture['stroke_width'])
-    with pytest.raises(ValueError):
-        _ = ezomero.post_roi(conn, im_id,
-                             shapes=roi_fixture['shapes'],
-                             name=roi_fixture['name'],
-                             description=roi_fixture['desc'],
-                             fill_color=(10, 10, 10),
-                             stroke_color=roi_fixture['stroke_color'],
-                             stroke_width=roi_fixture['stroke_width'])
-    with pytest.raises(TypeError):
-        _ = ezomero.post_roi(conn, im_id,
-                             shapes=roi_fixture['shapes'],
-                             name=roi_fixture['name'],
-                             description=roi_fixture['desc'],
-                             fill_color=roi_fixture['fill_color'],
-                             stroke_color=[10, 10, 10, 10],
-                             stroke_width=roi_fixture['stroke_width'])
-    with pytest.raises(ValueError):
-        _ = ezomero.post_roi(conn, im_id,
-                             shapes=roi_fixture['shapes'],
-                             name=roi_fixture['name'],
-                             description=roi_fixture['desc'],
-                             fill_color=roi_fixture['fill_color'],
-                             stroke_color=(10, 10, 10),
-                             stroke_width=roi_fixture['stroke_width'])
-    with pytest.raises(TypeError):
-        _ = ezomero.post_roi(conn, im_id,
-                             shapes=roi_fixture['shapes'],
-                             name=roi_fixture['name'],
-                             description=roi_fixture['desc'],
-                             fill_color=roi_fixture['fill_color'],
-                             stroke_color=roi_fixture['stroke_color'],
-                             stroke_width='width')
+                             description=roi_fixture['desc'])
 # "regular" test
     roi_id = ezomero.post_roi(conn, im_id,
                               shapes=roi_fixture['shapes'],
                               name=roi_fixture['name'],
-                              description=roi_fixture['desc'],
-                              fill_color=roi_fixture['fill_color'],
-                              stroke_color=roi_fixture['stroke_color'],
-                              stroke_width=roi_fixture['stroke_width'])
+                              description=roi_fixture['desc'])
     roi_in_omero = conn.getObject('Roi', roi_id)
     assert roi_in_omero.getName() == roi_fixture['name']
     assert roi_in_omero.getDescription() == roi_fixture['desc']

--- a/tests/test_rois.py
+++ b/tests/test_rois.py
@@ -3,14 +3,27 @@ from ezomero.rois import Polyline, Label
 
 
 def test_point_constructor():
-    point = Point(x=4.0, y=5.0, z=1, c=0, t=5, label='test_point')
-    assert point
+    point1 = Point(1.0, 2.0)
+    assert point1
+    point2 = Point(x=4.0, y=5.0, z=1, c=0, t=5, label='test_point')
+    assert point2
+    point3 = Point(x=3.0, y=7.0, z=2, c=1, t=4, label='test_point2',
+                   fill_color=(0, 0, 0, 0), stroke_color=(255, 255, 0),
+                   stroke_width=2.0)
+    assert point3
 
 
 def test_line_constructor():
-    line = Line(x1=4.0, y1=5.0, x2=7.0, y2=9.0,
-                z=1, c=0, t=5, label='test_line')
-    assert line
+    line1 = Line(1.0, 2.0, 3.0, 4.0)
+    assert line1
+    line2 = Line(x1=4.0, y1=5.0, x2=7.0, y2=9.0,
+                 z=1, c=0, t=5, label='test_line')
+    assert line2
+    line3 = Line(x1=4.0, y1=5.0, x2=7.0, y2=9.0,
+                 z=1, c=0, t=5, label='test_line',
+                 fill_color=(0, 0, 0, 0), stroke_color=(255, 255, 0),
+                 stroke_width=2.0)
+    assert line3
     arrow = Line(x1=2.0, y1=3.0, x2=3.0, y2=4.0,
                  z=1, c=0, t=5, label='test_arrow',
                  markerStart="Arrow", markerEnd="Arrow")
@@ -18,30 +31,64 @@ def test_line_constructor():
 
 
 def test_rectangle_constructor():
-    rectangle = Rectangle(x=4.0, y=5.0, width=30.0, height=40.0,
-                          z=1, c=0, t=5, label='test_rectangle')
-    assert rectangle
+    rectangle1 = Rectangle(1.0, 2.0, 3.0, 4.0)
+    assert rectangle1
+    rectangle2 = Rectangle(x=4.0, y=5.0, width=30.0, height=40.0,
+                           z=1, c=0, t=5, label='test_rectangle')
+    assert rectangle2
+    rectangle3 = Rectangle(x=4.0, y=5.0, width=30.0, height=40.0,
+                           z=1, c=0, t=5, label='test_rectangle',
+                           fill_color=(0, 0, 0, 0), stroke_color=(255, 255, 0),
+                           stroke_width=2.0)
+    assert rectangle3
 
 
 def test_ellipse_constructor():
-    ellipse = Ellipse(x=4, y=5, x_rad=30.0, y_rad=40.0, z=1,
-                      c=0, t=5, label='test_ellipse')
-    assert ellipse
+    ellipse1 = Ellipse(1.0, 2.0, 3.0, 4.0)
+    assert ellipse1
+    ellipse2 = Ellipse(x=4, y=5, x_rad=30.0, y_rad=40.0, z=1,
+                       c=0, t=5, label='test_ellipse')
+    assert ellipse2
+    ellipse3 = Ellipse(x=4, y=5, x_rad=30.0, y_rad=40.0, z=1,
+                       c=0, t=5, label='test_ellipse',
+                       fill_color=(0, 0, 0, 0), stroke_color=(255, 255, 0),
+                       stroke_width=2.0)
+    assert ellipse3
 
 
 def test_polygon_constructor():
-    polygon = Polygon(points=[(4.0, 5.0), (14.0, 15.0), (4.0, 15.0)],
-                      z=1, c=0, t=5, label='test_polygon')
-    assert polygon
+    polygon1 = Polygon([(1.0, 2.0), (3.0, 4.0), (5.0, 6.0)])
+    assert polygon1
+    polygon2 = Polygon(points=[(4.0, 5.0), (14.0, 15.0), (4.0, 15.0)],
+                       z=1, c=0, t=5, label='test_polygon')
+    assert polygon2
+    polygon3 = Polygon(points=[(4.0, 5.0), (14.0, 15.0), (4.0, 15.0)],
+                       z=1, c=0, t=5, label='test_polygon',
+                       fill_color=(0, 0, 0, 0), stroke_color=(255, 255, 0),
+                       stroke_width=2.0)
+    assert polygon3
 
 
 def test_polyline_constructor():
-    polyline = Polyline(points=[(4.0, 5.0), (14.0, 15.0), (4.0, 15.0)],
-                        z=1, c=0, t=5, label='test_polyline')
-    assert polyline
+    polyline1 = Polyline([(1.0, 2.0), (3.0, 4.0), (5.0, 6.0)])
+    assert polyline1
+    polyline2 = Polyline(points=[(4.0, 5.0), (14.0, 15.0), (4.0, 15.0)],
+                         z=1, c=0, t=5, label='test_polyline')
+    assert polyline2
+    polyline3 = Polyline(points=[(4.0, 5.0), (14.0, 15.0), (4.0, 15.0)],
+                         z=1, c=0, t=5, label='test_polyline',
+                         fill_color=(0, 0, 0, 0), stroke_color=(255, 255, 0),
+                         stroke_width=2.0)
+    assert polyline3
 
 
 def test_label_constructor():
-    label = Label(x=4.0, y=5.0, z=1, c=0, t=5, label='test_label',
-                  fontSize=60)
-    assert label
+    label1 = Label(1.0, 2.0, "test_label", 60)
+    assert label1
+    label2 = Label(x=4.0, y=5.0, z=1, c=0, t=5, label='test_label',
+                   fontSize=60)
+    assert label2
+    label3 = Label(x=4.0, y=5.0, z=1, c=0, t=5, label='test_label',
+                   fontSize=60, fill_color=(0, 0, 0, 0),
+                   stroke_color=(255, 255, 0), stroke_width=2.0)
+    assert label3


### PR DESCRIPTION
## Description

This work covers issue #65. We have moved those parameters to the `Shape` object instead of `ROI`, so that a single ROI with shapes of differing colors and widths can exist.


## Checklist

Docstrings updated, passing test, flake8 and type hinting

<!-- For detailed information on these and other aspects see -->
<!-- the ezomero contribution guidelines. -->
<!-- https://github.com/TheJacksonLaboratory/ezomero/CONTRIBUTING.md -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.

