### PR TITLE
Removed 'from attr import dataclass' from tests

### DIFF
--- a/tests/test_gets.py
+++ b/tests/test_gets.py
@@ -1,4 +1,3 @@
-from attr import dataclass
 import pytest
 import numpy as np
 import ezomero

--- a/tests/test_posts.py
+++ b/tests/test_posts.py
@@ -1,4 +1,3 @@
-from attr import dataclass
 import pytest
 import numpy as np
 import ezomero

--- a/tests/test_puts.py
+++ b/tests/test_puts.py
@@ -1,4 +1,3 @@
-from attr import dataclass
 import pytest
 import ezomero
 


### PR DESCRIPTION
pytest no longer includes attrs as a dependency since the Apr 8th update, which broke the attr import statement in test scripts. Based on some shallow testing, I don't think those import statements were necessary for the test scripts as-is, so I removed them, but they could also likely be replaced with `from dataclasses import dataclass`

