### PR TITLE
allow newer omero-py versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
     url="https://github.com/TheJacksonLaboratory/ezomero",
     packages=setuptools.find_packages(),
     install_requires=[
-        'omero-py==5.11.2',
+        'omero-py>=5.11.2',
         'numpy>=1.22',
         'dataclasses;python_version<"3.7"'
     ],


### PR DESCRIPTION
## Description

Currently `ezomero` forces an old `omero-py` version even though the newer versions work fine. Would be great to change the `setup.py` accordingly.

