### PR TITLE
`put_description` implemented

### DIFF
--- a/.github/workflows/upload_to_test_pypi.yml
+++ b/.github/workflows/upload_to_test_pypi.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.6
+    - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: 3.6
+        python-version: 3.8
     - name: Install Tools
       run: |
         python -m pip install --upgrade pip

--- a/ezomero/__init__.py
+++ b/ezomero/__init__.py
@@ -1,4 +1,5 @@
 from ._ezomero import (put_map_annotation,
+                       put_description,
                        connect,
                        store_connection_params,
                        set_group)
@@ -69,6 +70,7 @@ __all__ = ['post_dataset',
            'get_table',
            'get_shape',
            'put_map_annotation',
+           'put_description',
            'filter_by_filename',
            'filter_by_kv',
            'filter_by_tag_value',

--- a/ezomero/_ezomero.py
+++ b/ezomero/_ezomero.py
@@ -131,6 +131,65 @@ def put_map_annotation(conn: BlitzGateway, map_ann_id: int, kv_dict: dict,
     return None
 
 
+@do_across_groups
+def put_description(conn: BlitzGateway, obj_type: str, obj_id: int, desc: str,
+                    across_groups: bool = True) -> None:
+    """Update an existing object description with a new value (string)
+
+    Parameters
+    ----------
+    conn : ``omero.gateway.BlitzGateway`` object
+        OMERO connection.
+    obj_type: str
+        The OMERO object type to have its description changed. Valid object
+        types are 'Image', 'Dataset', 'Project', 'FileAnnotation', 
+        'CommentAnnotation', 'MapAnnotation', 'TagAnnotation, 'Plate', 
+        'Screen' and 'Roi'.
+    obj_id : int
+        ID of the object whose description will be replaced.
+    desc : str
+        New description for the object.
+    across_groups : bool, optional
+        Defines cross-group behavior of function - set to
+        ``False`` to disable it.
+
+    Returns
+    -------
+    Returns None.
+
+    Examples
+    --------
+    # Change an image description:
+
+    >>> new_desc = "This is a new description"
+    >>> put_description(conn, 'Image', 15, new_desc)
+
+    # Change a TagAnnotation description:
+
+    >>> put_description(conn, 'TagAnnotation', 16, 'new tag description')
+    """
+    if type(map_ann_id) is not int:
+        raise TypeError('Map annotation ID must be an integer')
+
+    map_ann = conn.getObject('MapAnnotation', map_ann_id)
+    if map_ann is None:
+        raise ValueError("MapAnnotation is non-existent or you do not have "
+                         "permissions to change it.")
+
+    if ns is None:
+        ns = map_ann.getNs()
+    map_ann.setNs(ns)
+
+    kv_pairs = []
+    for k, v in kv_dict.items():
+        k = str(k)
+        v = str(v)
+        kv_pairs.append([k, v])
+    map_ann.setValue(kv_pairs)
+    map_ann.save()
+    return None
+
+
 # functions for managing connection context and service options.
 
 def connect(user: Optional[str] = None, password: Optional[str] = None,

--- a/ezomero/_ezomero.py
+++ b/ezomero/_ezomero.py
@@ -142,8 +142,8 @@ def put_description(conn: BlitzGateway, obj_type: str, obj_id: int, desc: str,
         OMERO connection.
     obj_type: str
         The OMERO object type to have its description changed. Valid object
-        types are 'Image', 'Dataset', 'Project', 'FileAnnotation', 
-        'CommentAnnotation', 'MapAnnotation', 'TagAnnotation, 'Plate', 
+        types are 'Image', 'Dataset', 'Project', 'FileAnnotation',
+        'CommentAnnotation', 'MapAnnotation', 'TagAnnotation', 'Plate',
         'Screen' and 'Roi'.
     obj_id : int
         ID of the object whose description will be replaced.
@@ -168,25 +168,31 @@ def put_description(conn: BlitzGateway, obj_type: str, obj_id: int, desc: str,
 
     >>> put_description(conn, 'TagAnnotation', 16, 'new tag description')
     """
-    if type(map_ann_id) is not int:
-        raise TypeError('Map annotation ID must be an integer')
+    VALID_TYPES = ['Image',
+                   'Dataset',
+                   'Project',
+                   'FileAnnotation',
+                   'CommentAnnotation',
+                   'MapAnnotation',
+                   'TagAnnotation',
+                   'Plate',
+                   'Screen',
+                   'Roi',
+                   ]
+    if type(obj_type) is not str:
+        raise TypeError('Object type must be a string')
+    if type(obj_id) is not int:
+        raise TypeError('Object ID must be an integer')
+    if obj_type not in VALID_TYPES:
+        raise ValueError('Object type specified is not valid')
 
-    map_ann = conn.getObject('MapAnnotation', map_ann_id)
-    if map_ann is None:
-        raise ValueError("MapAnnotation is non-existent or you do not have "
+    obj = conn.getObject(obj_type, obj_id)
+    if obj is None:
+        raise ValueError("Object is non-existent or you do not have "
                          "permissions to change it.")
 
-    if ns is None:
-        ns = map_ann.getNs()
-    map_ann.setNs(ns)
-
-    kv_pairs = []
-    for k, v in kv_dict.items():
-        k = str(k)
-        v = str(v)
-        kv_pairs.append([k, v])
-    map_ann.setValue(kv_pairs)
-    map_ann.save()
+    obj.setDescription(str(desc))
+    obj.save()
     return None
 
 

--- a/tests/test_puts.py
+++ b/tests/test_puts.py
@@ -70,3 +70,70 @@ def test_put_map_annotation(conn, project_structure, users_groups):
                        deleteAnns=True,
                        deleteChildren=True,
                        wait=True)
+    
+
+def test_put_description(conn, project_structure, users_groups):
+    desc = "test description"
+
+    # test sanitized input
+    with pytest.raises(TypeError):
+        _ = ezomero.put_description(conn, 10, 'Image', desc)
+    with pytest.raises(TypeError):
+        _ = ezomero.put_description(conn, 'Image', '10', desc)
+    with pytest.raises(ValueError):
+        _ = ezomero.put_description(conn, 'FakeImage', 1, desc)
+
+    image_info = project_structure[2]
+    im_id = image_info[0][1]
+    map_ann_id = ezomero.post_map_annotation(conn, "Image", im_id, kv, ns)
+    kv = {"key1": "changed1",
+          "key2": "value2"}
+    ezomero.put_map_annotation(conn, map_ann_id, kv)
+    kv_pairs = ezomero.get_map_annotation(conn, map_ann_id)
+    assert kv_pairs['key1'] == kv['key1']
+
+    # test cross-group
+    kv = {"key1": "value1",
+          "key2": "value2"}
+    username = users_groups[1][0][0]  # test_user1
+    groupname = users_groups[0][0][0]  # test_group_1
+    current_conn = conn.suConn(username, groupname)
+    im_id2 = image_info[2][1]  # im2, in test_group_2
+    map_ann_id2 = ezomero.post_map_annotation(current_conn, "Image", im_id2,
+                                              kv, ns)
+    print(map_ann_id2)
+    kv = {"key1": "changed1",
+          "key2": "value2"}
+    ezomero.put_map_annotation(current_conn, map_ann_id2, kv)
+    kv_pairs = ezomero.get_map_annotation(current_conn, map_ann_id2)
+    assert kv_pairs['key1'] == kv['key1']
+    current_conn.close()
+
+    # test cross-group, across_groups unset
+    kv = {"key1": "value1",
+          "key2": "value2"}
+    username = users_groups[1][0][0]  # test_user1
+    groupname = users_groups[0][0][0]  # test_group_1
+    current_conn = conn.suConn(username, groupname)
+    im_id3 = image_info[2][1]  # im2, in test_group_2
+    map_ann_id3 = ezomero.post_map_annotation(current_conn, "Image", im_id3,
+                                              kv, ns)
+    print(map_ann_id3)
+    kv_changed = {"key1": "changed1",
+                  "key2": "value2"}
+    with pytest.raises(ValueError):
+        ezomero.put_map_annotation(current_conn, map_ann_id3, kv_changed,
+                                   across_groups=False)
+    kv_pairs = ezomero.get_map_annotation(current_conn, map_ann_id3)
+    assert kv_pairs['key1'] == kv['key1']
+    current_conn.close()
+
+    # test non-existent ID
+    with pytest.raises(ValueError):
+        ezomero.put_map_annotation(conn, 9999999, kv)
+
+    conn.deleteObjects("Annotation",
+                       [map_ann_id, map_ann_id2],
+                       deleteAnns=True,
+                       deleteChildren=True,
+                       wait=True)

--- a/tests/test_puts.py
+++ b/tests/test_puts.py
@@ -85,55 +85,31 @@ def test_put_description(conn, project_structure, users_groups):
 
     image_info = project_structure[2]
     im_id = image_info[0][1]
-    map_ann_id = ezomero.post_map_annotation(conn, "Image", im_id, kv, ns)
-    kv = {"key1": "changed1",
-          "key2": "value2"}
-    ezomero.put_map_annotation(conn, map_ann_id, kv)
-    kv_pairs = ezomero.get_map_annotation(conn, map_ann_id)
-    assert kv_pairs['key1'] == kv['key1']
+    ezomero.put_description(conn, 'Image', im_id, desc)
+    img, _ = ezomero.get_image(conn, im_id, no_pixels=True)
+    assert img.getDescription() == desc
 
     # test cross-group
-    kv = {"key1": "value1",
-          "key2": "value2"}
     username = users_groups[1][0][0]  # test_user1
     groupname = users_groups[0][0][0]  # test_group_1
     current_conn = conn.suConn(username, groupname)
     im_id2 = image_info[2][1]  # im2, in test_group_2
-    map_ann_id2 = ezomero.post_map_annotation(current_conn, "Image", im_id2,
-                                              kv, ns)
-    print(map_ann_id2)
-    kv = {"key1": "changed1",
-          "key2": "value2"}
-    ezomero.put_map_annotation(current_conn, map_ann_id2, kv)
-    kv_pairs = ezomero.get_map_annotation(current_conn, map_ann_id2)
-    assert kv_pairs['key1'] == kv['key1']
+    ezomero.put_description(conn, 'Image', im_id2, desc)
+    img, _ = ezomero.get_image(conn, im_id2, no_pixels=True)
+    assert img.getDescription() == desc
     current_conn.close()
 
     # test cross-group, across_groups unset
-    kv = {"key1": "value1",
-          "key2": "value2"}
     username = users_groups[1][0][0]  # test_user1
     groupname = users_groups[0][0][0]  # test_group_1
     current_conn = conn.suConn(username, groupname)
     im_id3 = image_info[2][1]  # im2, in test_group_2
-    map_ann_id3 = ezomero.post_map_annotation(current_conn, "Image", im_id3,
-                                              kv, ns)
-    print(map_ann_id3)
-    kv_changed = {"key1": "changed1",
-                  "key2": "value2"}
-    with pytest.raises(ValueError):
-        ezomero.put_map_annotation(current_conn, map_ann_id3, kv_changed,
-                                   across_groups=False)
-    kv_pairs = ezomero.get_map_annotation(current_conn, map_ann_id3)
-    assert kv_pairs['key1'] == kv['key1']
+    ezomero.put_description(conn, 'Image', im_id3, desc)
+    img, _ = ezomero.get_image(conn, im_id3, no_pixels=True)
+    assert img.getDescription() == desc
     current_conn.close()
 
     # test non-existent ID
     with pytest.raises(ValueError):
-        ezomero.put_map_annotation(conn, 9999999, kv)
+        ezomero.put_description(conn, 'Image', 9999999, desc)
 
-    conn.deleteObjects("Annotation",
-                       [map_ann_id, map_ann_id2],
-                       deleteAnns=True,
-                       deleteChildren=True,
-                       wait=True)

--- a/tests/test_puts.py
+++ b/tests/test_puts.py
@@ -70,7 +70,7 @@ def test_put_map_annotation(conn, project_structure, users_groups):
                        deleteAnns=True,
                        deleteChildren=True,
                        wait=True)
-    
+
 
 def test_put_description(conn, project_structure, users_groups):
     desc = "test description"
@@ -112,4 +112,3 @@ def test_put_description(conn, project_structure, users_groups):
     # test non-existent ID
     with pytest.raises(ValueError):
         ezomero.put_description(conn, 'Image', 9999999, desc)
-


### PR DESCRIPTION
## Description

This adds a `put_description` function that can edit descriptions in a number of objects.


## Checklist

New function has docstrings, unit tests and was flake8ed

<!-- For detailed information on these and other aspects see -->
<!-- the ezomero contribution guidelines. -->
<!-- https://github.com/TheJacksonLaboratory/ezomero/CONTRIBUTING.md -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.

