### PR TITLE
fixed typo that set fill color instead of stroke color

### DIFF
--- a/ezomero/_posts.py
+++ b/ezomero/_posts.py
@@ -798,7 +798,7 @@ def _shape_to_omero_shape(shape: Union[Point, Line, Rectangle, Ellipse,
     if shape.stroke_color is not None:
         omero_shape.setStrokeColor(rint(_rgba_to_int(shape.stroke_color)))
     else:
-        omero_shape.setFillColor(rint(_rgba_to_int((255, 255, 0, 255))))
+        omero_shape.setStrokeColor(rint(_rgba_to_int((255, 255, 0, 255))))
     if shape.stroke_width is not None:
         omero_shape.setStrokeWidth(LengthI(shape.stroke_width,
                                            enums.UnitsLength.PIXEL))


### PR DESCRIPTION


## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what it is implementing. -->
In _shape_to_omero_shape(), if stroke_color was not specified then the else statement accidentally set the fill_color to yellow instead of the stroke_color, resulting in yellow-filled polygons by default. 

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the ezomero contribution guidelines. -->
<!-- https://github.com/TheJacksonLaboratory/ezomero/CONTRIBUTING.md -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.

