### PR TITLE
fixing leftover datasets when `post_dataset` fails to link it to a project

### DIFF
--- a/ezomero/_posts.py
+++ b/ezomero/_posts.py
@@ -16,6 +16,7 @@ from omero.gateway import ScreenWrapper, FileAnnotationWrapper
 from omero.gateway import MapAnnotationWrapper, OriginalFileWrapper
 from omero.gateway import CommentAnnotationWrapper
 from omero.rtypes import rstring, rint, rdouble
+from omero import SecurityViolation
 from .rois import Point, Line, Rectangle, Ellipse
 from .rois import Polygon, Polyline, Label
 import importlib.util
@@ -100,7 +101,7 @@ def post_dataset(conn: BlitzGateway, dataset_name: str,
         try:
             link_datasets_to_project(conn, [dataset.getId()], project_id)
             return dataset.getId()
-        except:
+        except SecurityViolation:
             logging.warning('You do not have permission to create new '
                             f'datasets in project {project_id}.')
             conn.deleteObject("Dataset", dataset.getId())
@@ -698,7 +699,7 @@ def create_columns(table: Any,
                    headers: bool) -> List[Column]:
     """Helper function to create the correct column types from a table"""
     cols = []
-    if type(table) == list:
+    if isinstance(table, list):
         if headers:
             titles = table[0]
             data = table[1:]
@@ -721,7 +722,7 @@ def create_columns(table: Any,
                 max_size = len(max(data[i], key=len))
                 cols.append(StringColumn(titles[i], '',
                             max_size, data[i]))
-    elif type(table) == pd.core.frame.DataFrame:
+    elif isinstance(table, pd.core.frame.DataFrame):
         df = table.convert_dtypes()
         ints = df.select_dtypes(include='int')
         for col in ints:

--- a/ezomero/_posts.py
+++ b/ezomero/_posts.py
@@ -94,10 +94,19 @@ def post_dataset(conn: BlitzGateway, dataset_name: str,
     if description is not None:
         dataset.setDescription(description)
     dataset.save()
+    print(dataset.getId())
 
     if project_id is not None:
-        link_datasets_to_project(conn, [dataset.getId()], project_id)
-    return dataset.getId()
+        try:
+            link_datasets_to_project(conn, [dataset.getId()], project_id)
+            return dataset.getId()
+        except:
+            logging.warning('You do not have permission to create new '
+                            f'datasets in project {project_id}.')
+            conn.deleteObject("Dataset", dataset.getId())
+            return None
+    else:
+        return dataset.getId()
 
 
 def post_image(conn: BlitzGateway, image: np.ndarray, image_name: str,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,7 +92,7 @@ def omero_params(request):
     web_host = request.config.getoption("--omero-web-host")
     port = request.config.getoption("--omero-port")
     secure = request.config.getoption("--omero-secure")
-    return(user, password, host, web_host, port, secure)
+    return (user, password, host, web_host, port, secure)
 
 
 @pytest.fixture(scope='session')

--- a/tests/test_gets.py
+++ b/tests/test_gets.py
@@ -538,7 +538,7 @@ def test_get_shape_and_get_shape_ids(conn, project_structure,
         shape = ezomero.get_shape(conn, shape_ids[i])
         assert hasattr(shape, 'label')
         for pre_shape in shapes:
-            if type(shape) == type(pre_shape):
+            if type(shape) is type(pre_shape):
                 assert shape.fill_color == pre_shape.fill_color
                 assert shape.stroke_color == pre_shape.stroke_color
                 assert shape.stroke_width == pre_shape.stroke_width

--- a/tests/test_posts.py
+++ b/tests/test_posts.py
@@ -38,7 +38,9 @@ def test_post_dataset(conn, project_structure, users_groups, timestamp):
     ds_test_name3 = 'test_post_dataset3_' + timestamp
     pid = 99999999
     did3 = ezomero.post_dataset(conn, ds_test_name3, project_id=pid)
+    ds_ids = ezomero.get_dataset_ids(conn)
     assert did3 is None
+    assert len(ds_ids) == 2
 
     # Dataset in cross-group project, valid permissions
     username = users_groups[1][0][0]  # test_user1
@@ -62,6 +64,8 @@ def test_post_dataset(conn, project_structure, users_groups, timestamp):
     project_info = project_structure[0]
     pid = project_info[1][1]  # proj1 (in test_group_1)
     did5 = ezomero.post_dataset(current_conn, ds_test_name5, project_id=pid)
+    ds_ids = ezomero.get_dataset_ids(current_conn)
+    assert len(ds_ids) == 1
     current_conn.close()
     assert did5 is None
 


### PR DESCRIPTION
## Description

This fixes #86 by deleting the created dataset when `post_dataset` with an optional `project` argument fails due to a security violation; this is normally when the project referred to by that ID belongs to another user in the same group and the current user does not have permission to write into it. New behavior is that, in that case, `post_dataset` returns `None` (as it already did) and no new dataset is created anywhere.


## Checklist

New unit test section for `post_dataset`. flake8 and mypy clean

<!-- For detailed information on these and other aspects see -->
<!-- the ezomero contribution guidelines. -->
<!-- https://github.com/TheJacksonLaboratory/ezomero/CONTRIBUTING.md -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.

