### PR TITLE
List Objects ID (images, dataset, project, ...) by tag ID

### DIFF
--- a/ezomero/__init__.py
+++ b/ezomero/__init__.py
@@ -43,7 +43,8 @@ from ._gets import (get_image,
                     get_original_filepaths,
                     get_pyramid_levels,
                     get_table,
-                    get_shape)
+                    get_shape,
+                    get_object_ids_by_tag)
 
 __all__ = ['post_dataset',
            'post_image',
@@ -75,6 +76,7 @@ __all__ = ['post_dataset',
            'get_pyramid_levels',
            'get_table',
            'get_shape',
+           'get_object_ids_by_tag',
            'put_map_annotation',
            'put_description',
            'filter_by_filename',

--- a/ezomero/_gets.py
+++ b/ezomero/_gets.py
@@ -1332,7 +1332,8 @@ def get_object_ids_by_tag(conn: BlitzGateway,
     assert set_operation in ["union", "difference", "intersection"], "set_operation must be one of ('union', 'intersection', 'difference')."
 
     if set_operation == "union":
-        return [obj.getId() for obj in conn.getObjectsByAnnotations(obj_type, tag_ids)]
+        id_l = [obj.getId() for obj in conn.getObjectsByAnnotations(obj_type, tag_ids)]
+        return list(set(id_l)) # Removing duplicates
     elif set_operation in ["intersection", "difference"]:
         obj_ids = set([obj.getId() for obj in conn.getObjectsByAnnotations(obj_type, tag_ids[0:1])])
         for tag_id in tag_ids[1:]:


### PR DESCRIPTION
## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what it is implementing. -->

Hello Eric,
I want to propose a function to list objects attached to tags `get_object_ids_by_tag`

Also includes a parameter describing how multiple tags should be combined according to one of the three set operations [union, intersection, difference].


## Checklist

- [ ] Recompile the doc
- [ ] Add new units tests
- [ ] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the ezomero contribution guidelines. -->
<!-- https://github.com/TheJacksonLaboratory/ezomero/CONTRIBUTING.md -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
