### PR TITLE
`post_file_annotation` can now create orphaned `FileAnnotation`s

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
     url="https://github.com/TheJacksonLaboratory/ezomero",
     packages=setuptools.find_packages(),
     install_requires=[
-        'omero-py == 5.13.1',
+        'omero-py == 5.16.1',
         'numpy >= 1.22, < 2.0'
     ],
     extras_require={

--- a/tests/test_gets.py
+++ b/tests/test_gets.py
@@ -389,15 +389,19 @@ def test_get_file_annotation_and_ids(conn, project_structure, tmp_path):
     file_path.write_text("hello world!")
     file_ann = str(file_path)
     ns = "jax.org/omeroutils/tests/v0"
-    file_ann_id = ezomero.post_file_annotation(conn, "Image", im_id,
-                                               file_ann, ns)
-    file_ann_id2 = ezomero.post_file_annotation(conn, "Image", im_id,
-                                                file_ann, ns)
-    file_ann_id3 = ezomero.post_file_annotation(conn, "Image", im_id,
-                                                file_ann, ns)
+    file_ann_id = ezomero.post_file_annotation(conn,
+                                               file_ann, ns,
+                                               "Image", im_id)
+    file_ann_id2 = ezomero.post_file_annotation(conn,
+                                                file_ann, ns,
+                                                "Image", im_id)
+    file_ann_id3 = ezomero.post_file_annotation(conn,
+                                                file_ann, ns,
+                                                "Image", im_id)
     ns2 = "different namespace"
-    file_ann_id4 = ezomero.post_file_annotation(conn, "Image", im_id,
-                                                file_ann, ns2)
+    file_ann_id4 = ezomero.post_file_annotation(conn,
+                                                file_ann, ns2,
+                                                "Image", im_id)
 
     # Test sanitizing inputs
     with pytest.raises(TypeError):

--- a/tests/test_posts.py
+++ b/tests/test_posts.py
@@ -318,22 +318,21 @@ def test_post_get_file_annotation(conn, project_structure, users_groups,
     ns = "jax.org/omeroutils/tests/v0"
     # test sanitized input on post
     with pytest.raises(TypeError):
-        _ = ezomero.post_file_annotation(conn, "Image", im_id, 10, ns)
+        _ = ezomero.post_file_annotation(conn, 10, ns, "Image", im_id)
     with pytest.raises(TypeError):
-        _ = ezomero.post_file_annotation(conn, "Image", '10', file_ann, ns)
-    with pytest.raises(TypeError):
-        _ = ezomero.post_file_annotation(conn, "Image", None, file_ann, ns)
+        _ = ezomero.post_file_annotation(conn, file_ann, ns, "Image", '10')
 
-    file_ann_id = ezomero.post_file_annotation(conn, "Image", im_id, file_ann,
-                                               ns)
+    file_ann_id = ezomero.post_file_annotation(conn, file_ann, ns,
+                                               "Image", im_id)
     return_ann = ezomero.get_file_annotation(conn, file_ann_id)
     assert filecmp.cmp(return_ann, file_ann)
     os.remove(return_ann)
 
     # Test posting to non-existing object
     im_id2 = 999999999
-    file_ann_id2 = ezomero.post_file_annotation(conn, "Image", im_id2,
-                                                file_ann, ns)
+    file_ann_id2 = ezomero.post_file_annotation(conn,
+                                                file_ann, ns,
+                                                "Image", im_id2)
     assert file_ann_id2 is None
 
     # Test posting cross-group
@@ -341,8 +340,9 @@ def test_post_get_file_annotation(conn, project_structure, users_groups,
     groupname = users_groups[0][0][0]  # test_group_1
     current_conn = conn.suConn(username, groupname)
     im_id3 = image_info[2][1]  # im2, in test_group_2
-    file_ann_id3 = ezomero.post_file_annotation(current_conn, "Image", im_id3,
-                                                file_ann, ns)
+    file_ann_id3 = ezomero.post_file_annotation(current_conn,
+                                                file_ann, ns,
+                                                "Image", im_id3)
     return_ann3 = ezomero.get_file_annotation(current_conn, file_ann_id3)
     assert filecmp.cmp(return_ann3, file_ann)
     os.remove(return_ann3)
@@ -353,8 +353,9 @@ def test_post_get_file_annotation(conn, project_structure, users_groups,
     groupname = users_groups[0][1][0]  # test_group_2
     current_conn = conn.suConn(username, groupname)
     im_id4 = image_info[1][1]  # im1(in test_group_1)
-    file_ann_id4 = ezomero.post_file_annotation(current_conn, "Image", im_id4,
-                                                file_ann, ns)
+    file_ann_id4 = ezomero.post_file_annotation(current_conn,
+                                                file_ann, ns,
+                                                "Image", im_id4)
     assert file_ann_id4 is None
     current_conn.close()
 
@@ -363,13 +364,36 @@ def test_post_get_file_annotation(conn, project_structure, users_groups,
     groupname = users_groups[0][0][0]  # test_group_1
     current_conn = conn.suConn(username, groupname)
     im_id5 = image_info[2][1]  # im2, in test_group_2
-    file_ann_id5 = ezomero.post_file_annotation(current_conn, "Image", im_id5,
+    file_ann_id5 = ezomero.post_file_annotation(current_conn,
                                                 file_ann, ns,
+                                                "Image", im_id5,
                                                 across_groups=False)
     assert file_ann_id5 is None
     current_conn.close()
 
-    conn.deleteObjects("Annotation", [file_ann_id, file_ann_id3],
+    # Test posting orphaned
+    current_conn = conn.suConn(username, groupname)
+    file_ann_id6 = ezomero.post_file_annotation(current_conn, file_ann, ns)
+    print(file_ann_id6)
+    return_ann6 = ezomero.get_file_annotation(current_conn, file_ann_id6)
+    assert filecmp.cmp(return_ann6, file_ann)
+    os.remove(return_ann6)
+
+    # Test posting orphaned, partial completion
+    file_ann_id7 = ezomero.post_file_annotation(conn, file_ann, ns, "Image")
+    return_ann7 = ezomero.get_file_annotation(conn, file_ann_id7)
+    assert filecmp.cmp(return_ann7, file_ann)
+    os.remove(return_ann7)
+
+    # Test posting orphaned, partial completion
+    file_ann_id8 = ezomero.post_file_annotation(conn, file_ann, ns,
+                                                object_id=10)
+    return_ann8 = ezomero.get_file_annotation(conn, file_ann_id8)
+    assert filecmp.cmp(return_ann8, file_ann)
+    os.remove(return_ann8)
+
+    conn.deleteObjects("Annotation", [file_ann_id, file_ann_id3, file_ann_id6,
+                                      file_ann_id7, file_ann_id8],
                        deleteAnns=True, deleteChildren=True, wait=True)
 
 


### PR DESCRIPTION
## Description

Currently, `post_file_annotation` can only create a `FileAnnotation`attached to an existing object. This update allows for orphaned `FileAnnotation`s too - important to create e.g. Figures.

Note; THIS CHANGES THE FUNCTION SIGNATURE. A few arguments are now optional, and need to come after positional arguments.


## Checklist

Docstrings updated, new unit tests added, flake8 passing.

<!-- For detailed information on these and other aspects see -->
<!-- the ezomero contribution guidelines. -->
<!-- https://github.com/TheJacksonLaboratory/ezomero/CONTRIBUTING.md -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.

