### PR TITLE
made Importer `zarr´ compatible

### DIFF
--- a/ezomero/_importer.py
+++ b/ezomero/_importer.py
@@ -301,6 +301,8 @@ class Importer:
             params = Parameters()
             path_query = self.make_substitutions()
             path_query = path_query.strip('/')
+            if path_query.endswith(".zarr"):
+                path_query = f"{path_query}/.zattrs"
             params.map = {"cpath": rstring(path_query)}
             results = q.projection(
                 "SELECT i.id FROM Image i"
@@ -468,6 +470,7 @@ class Importer:
                     '-k', self.conn.getSession().getUuid().val,
                     '-s', self.conn.host,
                     '-p', str(self.conn.port),
+                    '--depth', '10',
                     '--transfer', 'ln_s',
                     str(self.file_path)])
         if cli.rv == 0:

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
     url="https://github.com/TheJacksonLaboratory/ezomero",
     packages=setuptools.find_packages(),
     install_requires=[
-        'omero-py == 5.18.0',
+        'omero-py == 5.19.0',
         'numpy >= 1.22, < 2.0'
     ],
     extras_require={


### PR DESCRIPTION
## Description

Fixes #97 

This PR implements the fixes suggested by @will-moore in [this image.sc thread](https://forum.image.sc/t/images-batch-import-into-a-dataset-in-omero-using-ezomero-2-1-0/89529/15) to allow for the import of `.zarr` files into OMERO through `ezomero`.


## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.

