### PR TITLE
pinning to versions of omero-py that have been tested

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
     url="https://github.com/TheJacksonLaboratory/ezomero",
     packages=setuptools.find_packages(),
     install_requires=[
-        'omero-py == 5.19.0',
+        'omero-py >= 5.13.0, < 5.20.0',
         'numpy >= 1.22, < 2.0'
     ],
     extras_require={


### PR DESCRIPTION
## Description

This PR changes our approach to defining omero-py versions to be much more permissive. I have tested current ezomero version all the way back to `omero-py=5.9.0` and tests pass, but I'm being conservative and pinning to `>=5.13.0, <5.22.0`.


## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.

