### PR TITLE
Map annotation enhancement; list of values possible

### DIFF
--- a/.github/workflows/run_tests_pr.yml
+++ b/.github/workflows/run_tests_pr.yml
@@ -7,7 +7,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run docker compose up
-        run: docker-compose -f tests/docker-compose.yml up -d
+        run: docker compose -f tests/docker-compose.yml up -d
       - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/run_tests_push.yml
+++ b/.github/workflows/run_tests_push.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run docker compose up
-        run: docker-compose -f tests/docker-compose.yml up -d
+        run: docker compose -f tests/docker-compose.yml up -d
       - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:

--- a/ezomero/_ezomero.py
+++ b/ezomero/_ezomero.py
@@ -102,7 +102,7 @@ def put_map_annotation(conn: BlitzGateway, map_ann_id: int, kv_dict: dict,
     --------
     # Change only the values of an existing map annotation:
 
-    >>> new_values = {'testkey': 'testvalue', 'testkey2': 'testvalue2'}
+    >>> new_values = {'key1': 'value1', 'key2': ['value2', 'value3']}
     >>> put_map_annotation(conn, 15, new_values)
 
     # Change both the values and namespace of an existing map annotation:
@@ -124,8 +124,14 @@ def put_map_annotation(conn: BlitzGateway, map_ann_id: int, kv_dict: dict,
     kv_pairs = []
     for k, v in kv_dict.items():
         k = str(k)
-        v = str(v)
-        kv_pairs.append([k, v])
+        if type(v) != list:
+            v = str(v)
+            kv_pairs.append([k, v])
+        else:
+            for value in v:
+                value = str(value)
+                kv_pairs.append([k, value])
+                
     map_ann.setValue(kv_pairs)
     map_ann.save()
     return None

--- a/ezomero/_gets.py
+++ b/ezomero/_gets.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import numpy as np
+from collections import defaultdict
 from typing import Optional, List, Union, Tuple, Literal
 from typing import Any
 from ._ezomero import do_across_groups
@@ -1152,22 +1153,17 @@ def get_map_annotation(conn: BlitzGateway, map_ann_id: int,
     --------
     >>> ma_dict = get_map_annotation(conn, 62)
     >>> print(ma_dict)
-    {'testkey': 'testvalue', 'testkey2': ['testvalue2'. 'testvalue3']}
+    {'testkey': ['testvalue'], 'testkey2': ['testvalue2'. 'testvalue3']}
     """
     if type(map_ann_id) is not int:
         raise TypeError('Map annotation ID must be an integer')
     
-    map_annotation_dict = {}
-    
     map_annotation = conn.getObject('MapAnnotation', map_ann_id).getValue()
 
+    map_annotation_dict = defaultdict(list)
+
     for item in map_annotation:
-        if item[0] in map_annotation_dict:
-            if not isinstance(map_annotation_dict[item[0]], list):
-                map_annotation_dict[item[0]] = [map_annotation_dict[item[0]]]
-            map_annotation_dict[item[0]].append(item[1])
-        else:
-            map_annotation_dict[item[0]] = item[1]
+        map_annotation_dict[item[0]].append(item[1])
 
     return map_annotation_dict
 

--- a/ezomero/_gets.py
+++ b/ezomero/_gets.py
@@ -1152,12 +1152,24 @@ def get_map_annotation(conn: BlitzGateway, map_ann_id: int,
     --------
     >>> ma_dict = get_map_annotation(conn, 62)
     >>> print(ma_dict)
-    {'testkey': 'testvalue', 'testkey2': 'testvalue2'}
+    {'testkey': 'testvalue', 'testkey2': ['testvalue2'. 'testvalue3']}
     """
     if type(map_ann_id) is not int:
         raise TypeError('Map annotation ID must be an integer')
+    
+    map_annotation_dict = {}
+    
+    map_annotation = conn.getObject('MapAnnotation', map_ann_id).getValue()
 
-    return dict(conn.getObject('MapAnnotation', map_ann_id).getValue())
+    for item in map_annotation:
+        if item[0] in map_annotation_dict:
+            if not isinstance(map_annotation_dict[item[0]], list):
+                map_annotation_dict[item[0]] = [map_annotation_dict[item[0]]]
+            map_annotation_dict[item[0]].append(item[1])
+        else:
+            map_annotation_dict[item[0]] = item[1]
+
+    return map_annotation_dict
 
 
 @do_across_groups

--- a/ezomero/_gets.py
+++ b/ezomero/_gets.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import numpy as np
-from collections import defaultdict
 from typing import Optional, List, Union, Tuple, Literal
 from typing import Any
 from ._ezomero import do_across_groups
@@ -1148,22 +1147,29 @@ def get_map_annotation(conn: BlitzGateway, map_ann_id: int,
     -------
     kv_dict : dict
         The value of the specified map annotation object, as a Python dict.
+        If kv-pairs with the same key exist, the corresponding dict value
+        will be a list.
 
     Examples
     --------
     >>> ma_dict = get_map_annotation(conn, 62)
     >>> print(ma_dict)
-    {'testkey': ['testvalue'], 'testkey2': ['testvalue2'. 'testvalue3']}
+    {'testkey': 'testvalue', 'testkey2': ['testvalue2'. 'testvalue3']}
     """
     if type(map_ann_id) is not int:
         raise TypeError('Map annotation ID must be an integer')
     
+    map_annotation_dict = {}
+    
     map_annotation = conn.getObject('MapAnnotation', map_ann_id).getValue()
 
-    map_annotation_dict = defaultdict(list)
-
     for item in map_annotation:
-        map_annotation_dict[item[0]].append(item[1])
+        if item[0] in map_annotation_dict:
+            if not isinstance(map_annotation_dict[item[0]], list):
+                map_annotation_dict[item[0]] = [map_annotation_dict[item[0]]]
+            map_annotation_dict[item[0]].append(item[1])
+        else:
+            map_annotation_dict[item[0]] = item[1]
 
     return map_annotation_dict
 

--- a/ezomero/_importer.py
+++ b/ezomero/_importer.py
@@ -166,8 +166,7 @@ def set_or_create_screen(conn: BlitzGateway, screen: Union[str, int],
 
 def multi_post_map_annotation(conn: BlitzGateway, object_type: str,
                               object_ids: Union[int, List[int]], kv_dict: dict,
-                              ns: str, across_groups: Optional[bool] = True
-                              ) -> int:
+                              ns: str) -> int:
     """Create a single new MapAnnotation and link to multiple images.
     Parameters
     ----------

--- a/ezomero/_importer.py
+++ b/ezomero/_importer.py
@@ -192,7 +192,7 @@ def multi_post_map_annotation(conn: BlitzGateway, object_type: str,
     --------
     >>> ns = 'jax.org/jax/example/namespace'
     >>> d = {'species': 'human',
-             'occupation': 'time traveler'
+             'occupation': ['time traveler', 'soldier'],
              'first name': 'Kyle',
              'surname': 'Reese'}
     >>> multi_post_map_annotation(conn, "Image", [23,56,78], d, ns)
@@ -212,8 +212,13 @@ def multi_post_map_annotation(conn: BlitzGateway, object_type: str,
     kv_pairs = []
     for k, v in kv_dict.items():
         k = str(k)
-        v = str(v)
-        kv_pairs.append([k, v])
+        if type(v) != list:
+            v = str(v)
+            kv_pairs.append([k, v])
+        else:
+            for value in v:
+                value = str(value)
+                kv_pairs.append([k, value])
 
     map_ann = MapAnnotationWrapper(conn)
     map_ann.setNs(str(ns))

--- a/ezomero/_posts.py
+++ b/ezomero/_posts.py
@@ -252,6 +252,8 @@ def post_map_annotation(conn: BlitzGateway, object_type: str, object_id: int,
     Notes
     -----
     All keys and values are converted to strings before saving in OMERO.
+    Passing a list of values will result in multiple instances of the key,
+    one for each value.
 
     Returns
     -------
@@ -262,7 +264,7 @@ def post_map_annotation(conn: BlitzGateway, object_type: str, object_id: int,
     --------
     >>> ns = 'jax.org/jax/example/namespace'
     >>> d = {'species': 'human',
-    ...      'occupation': 'time traveler'
+    ...      'occupation': ['time traveler', 'soldier'].
     ...      'first name': 'Kyle',
     ...      'surname': 'Reese'}
     >>> post_map_annotation(conn, "Image", 56, d, ns)
@@ -274,8 +276,13 @@ def post_map_annotation(conn: BlitzGateway, object_type: str, object_id: int,
     kv_pairs = []
     for k, v in kv_dict.items():
         k = str(k)
-        v = str(v)
-        kv_pairs.append([k, v])
+        if type(v) != list:
+            v = str(v)
+            kv_pairs.append([k, v])
+        else:
+            for value in v:
+                value = str(value)
+                kv_pairs.append([k, value])
     obj = None
     if object_id is not None:
         if type(object_id) is not int:

--- a/tests/test_gets.py
+++ b/tests/test_gets.py
@@ -472,8 +472,8 @@ def test_get_map_annotation_and_ids(conn, project_structure):
     with pytest.raises(TypeError):
         _ = ezomero.get_map_annotation(conn, '10')
     mpann = ezomero.get_map_annotation(conn, map_ann_ids[0])
-    assert mpann["key1"] == kv["key1"]
-    assert mpann["key2"] == kv["key2"]
+    assert mpann["key1"][0] == kv["key1"]
+    assert mpann["key2"][0] == kv["key2"]
     assert sorted(mpann["key3"]) == sorted(kv["key3"])
     conn.deleteObjects("Annotation",
                        [map_ann_id, map_ann_id2, map_ann_id3, map_ann_id4],

--- a/tests/test_gets.py
+++ b/tests/test_gets.py
@@ -472,8 +472,8 @@ def test_get_map_annotation_and_ids(conn, project_structure):
     with pytest.raises(TypeError):
         _ = ezomero.get_map_annotation(conn, '10')
     mpann = ezomero.get_map_annotation(conn, map_ann_ids[0])
-    assert mpann["key1"][0] == kv["key1"]
-    assert mpann["key2"][0] == kv["key2"]
+    assert mpann["key1"] == kv["key1"]
+    assert mpann["key2"] == kv["key2"]
     assert sorted(mpann["key3"]) == sorted(kv["key3"])
     conn.deleteObjects("Annotation",
                        [map_ann_id, map_ann_id2, map_ann_id3, map_ann_id4],

--- a/tests/test_gets.py
+++ b/tests/test_gets.py
@@ -443,7 +443,8 @@ def test_get_image_ids_params(conn):
 
 def test_get_map_annotation_and_ids(conn, project_structure):
     kv = {"key1": "value1",
-          "key2": "value2"}
+          "key2": "value2",
+          "key3": ["value3", "value4"]}
     ns = "jax.org/omeroutils/tests/v0"
     image_info = project_structure[2]
     im_id = image_info[0][1]
@@ -471,7 +472,9 @@ def test_get_map_annotation_and_ids(conn, project_structure):
     with pytest.raises(TypeError):
         _ = ezomero.get_map_annotation(conn, '10')
     mpann = ezomero.get_map_annotation(conn, map_ann_ids[0])
-    assert mpann == kv
+    assert mpann["key1"] == kv["key1"]
+    assert mpann["key2"] == kv["key2"]
+    assert sorted(mpann["key3"]) == sorted(kv["key3"])
     conn.deleteObjects("Annotation",
                        [map_ann_id, map_ann_id2, map_ann_id3, map_ann_id4],
                        deleteAnns=True,

--- a/tests/test_posts.py
+++ b/tests/test_posts.py
@@ -183,7 +183,8 @@ def test_post_get_map_annotation(conn, project_structure, users_groups):
     im_id = image_info[0][1]
     # This test both ezomero.post_map_annotation and ezomero.get_map_annotation
     kv = {"key1": "value1",
-          "key2": "value2"}
+          "key2": "value2",
+          "key3": ["value3", 123]}
     ns = "jax.org/omeroutils/tests/v0"
 
     # test sanitized input on post
@@ -197,6 +198,7 @@ def test_post_get_map_annotation(conn, project_structure, users_groups):
     map_ann_id = ezomero.post_map_annotation(conn, "Image", im_id, kv, ns)
     kv_pairs = ezomero.get_map_annotation(conn, map_ann_id)
     assert kv_pairs["key2"] == "value2"
+    assert kv_pairs["key3"] == ["value3", 123]
 
     # Test posting to non-existing object
     im_id2 = 999999999

--- a/tests/test_posts.py
+++ b/tests/test_posts.py
@@ -198,7 +198,7 @@ def test_post_get_map_annotation(conn, project_structure, users_groups):
     map_ann_id = ezomero.post_map_annotation(conn, "Image", im_id, kv, ns)
     kv_pairs = ezomero.get_map_annotation(conn, map_ann_id)
     assert kv_pairs["key2"] == "value2"
-    assert kv_pairs["key3"] == ["value3", 123]
+    assert sorted(kv_pairs["key3"]) == sorted(["value3", "123"])
 
     # Test posting to non-existing object
     im_id2 = 999999999

--- a/tests/test_posts.py
+++ b/tests/test_posts.py
@@ -197,7 +197,7 @@ def test_post_get_map_annotation(conn, project_structure, users_groups):
 
     map_ann_id = ezomero.post_map_annotation(conn, "Image", im_id, kv, ns)
     kv_pairs = ezomero.get_map_annotation(conn, map_ann_id)
-    assert kv_pairs["key2"][0] == "value2"
+    assert kv_pairs["key2"] == "value2"
     assert sorted(kv_pairs["key3"]) == sorted(["value3", "123"])
 
     # Test posting to non-existing object
@@ -213,7 +213,7 @@ def test_post_get_map_annotation(conn, project_structure, users_groups):
     map_ann_id3 = ezomero.post_map_annotation(current_conn, "Image", im_id3,
                                               kv, ns)
     kv_pairs3 = ezomero.get_map_annotation(current_conn, map_ann_id3)
-    assert kv_pairs3["key2"][0] == "value2"
+    assert kv_pairs3["key2"] == "value2"
     current_conn.close()
 
     # Test posting to an invalid cross-group

--- a/tests/test_posts.py
+++ b/tests/test_posts.py
@@ -197,7 +197,7 @@ def test_post_get_map_annotation(conn, project_structure, users_groups):
 
     map_ann_id = ezomero.post_map_annotation(conn, "Image", im_id, kv, ns)
     kv_pairs = ezomero.get_map_annotation(conn, map_ann_id)
-    assert kv_pairs["key2"] == "value2"
+    assert kv_pairs["key2"][0] == "value2"
     assert sorted(kv_pairs["key3"]) == sorted(["value3", "123"])
 
     # Test posting to non-existing object
@@ -213,7 +213,7 @@ def test_post_get_map_annotation(conn, project_structure, users_groups):
     map_ann_id3 = ezomero.post_map_annotation(current_conn, "Image", im_id3,
                                               kv, ns)
     kv_pairs3 = ezomero.get_map_annotation(current_conn, map_ann_id3)
-    assert kv_pairs3["key2"] == "value2"
+    assert kv_pairs3["key2"][0] == "value2"
     current_conn.close()
 
     # Test posting to an invalid cross-group

--- a/tests/test_puts.py
+++ b/tests/test_puts.py
@@ -23,7 +23,7 @@ def test_put_map_annotation(conn, project_structure, users_groups):
           "key2": "value2"}
     ezomero.put_map_annotation(conn, map_ann_id, kv)
     kv_pairs = ezomero.get_map_annotation(conn, map_ann_id)
-    assert kv_pairs['key1'][0] == kv['key1']
+    assert kv_pairs['key1'] == kv['key1']
 
     # test cross-group
     kv = {"key1": "value1",

--- a/tests/test_puts.py
+++ b/tests/test_puts.py
@@ -23,7 +23,7 @@ def test_put_map_annotation(conn, project_structure, users_groups):
           "key2": "value2"}
     ezomero.put_map_annotation(conn, map_ann_id, kv)
     kv_pairs = ezomero.get_map_annotation(conn, map_ann_id)
-    assert sorted(kv_pairs['key1']) == sorted(kv['key1'])
+    assert kv_pairs['key1'][0] == kv['key1']
 
     # test cross-group
     kv = {"key1": "value1",
@@ -39,7 +39,7 @@ def test_put_map_annotation(conn, project_structure, users_groups):
           "key2": "value2"}
     ezomero.put_map_annotation(current_conn, map_ann_id2, kv)
     kv_pairs = ezomero.get_map_annotation(current_conn, map_ann_id2)
-    assert kv_pairs['key1'] == kv['key1']
+    assert kv_pairs['key1'][0] == kv['key1']
     current_conn.close()
 
     # test cross-group, across_groups unset
@@ -58,7 +58,7 @@ def test_put_map_annotation(conn, project_structure, users_groups):
         ezomero.put_map_annotation(current_conn, map_ann_id3, kv_changed,
                                    across_groups=False)
     kv_pairs = ezomero.get_map_annotation(current_conn, map_ann_id3)
-    assert kv_pairs['key1'] == kv['key1']
+    assert kv_pairs['key1'][0] == kv['key1']
     current_conn.close()
 
     # test non-existent ID

--- a/tests/test_puts.py
+++ b/tests/test_puts.py
@@ -19,11 +19,11 @@ def test_put_map_annotation(conn, project_structure, users_groups):
     image_info = project_structure[2]
     im_id = image_info[0][1]
     map_ann_id = ezomero.post_map_annotation(conn, "Image", im_id, kv, ns)
-    kv = {"key1": "changed1",
+    kv = {"key1": ["changed1", "changed2"],
           "key2": "value2"}
     ezomero.put_map_annotation(conn, map_ann_id, kv)
     kv_pairs = ezomero.get_map_annotation(conn, map_ann_id)
-    assert kv_pairs['key1'] == kv['key1']
+    assert sorted(kv_pairs['key1']) == sorted(kv['key1'])
 
     # test cross-group
     kv = {"key1": "value1",

--- a/tests/test_puts.py
+++ b/tests/test_puts.py
@@ -23,7 +23,7 @@ def test_put_map_annotation(conn, project_structure, users_groups):
           "key2": "value2"}
     ezomero.put_map_annotation(conn, map_ann_id, kv)
     kv_pairs = ezomero.get_map_annotation(conn, map_ann_id)
-    assert kv_pairs['key1'] == kv['key1']
+    assert sorted(kv_pairs['key1']) == sorted(kv['key1'])
 
     # test cross-group
     kv = {"key1": "value1",
@@ -39,7 +39,7 @@ def test_put_map_annotation(conn, project_structure, users_groups):
           "key2": "value2"}
     ezomero.put_map_annotation(current_conn, map_ann_id2, kv)
     kv_pairs = ezomero.get_map_annotation(current_conn, map_ann_id2)
-    assert kv_pairs['key1'][0] == kv['key1']
+    assert kv_pairs['key1'] == kv['key1']
     current_conn.close()
 
     # test cross-group, across_groups unset
@@ -58,7 +58,7 @@ def test_put_map_annotation(conn, project_structure, users_groups):
         ezomero.put_map_annotation(current_conn, map_ann_id3, kv_changed,
                                    across_groups=False)
     kv_pairs = ezomero.get_map_annotation(current_conn, map_ann_id3)
-    assert kv_pairs['key1'][0] == kv['key1']
+    assert kv_pairs['key1'] == kv['key1']
     current_conn.close()
 
     # test non-existent ID


### PR DESCRIPTION
## Description

This tries to implement the option to pass a Key-Value dict containing multiple values for one key which then will create multiple Key-Value pairs in OMERO.
Multiple instances of the key, each with one value.
`kv_dict = {"key1": ["value1", "value2"]}`
would become in OMERO:
```
key1 : value1
key1 : value2
```
The reason for this is, that I needed/wanted it, as the same functionality is also present in the new "KeyValue_from_csv" OMERO.web scripts.
And it doesn't make sense to me, that the python package should have less functionality.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

It seems to me like I checked everything.
But please double check, as I am not intimately familiar where I have to adapt things everywhere, as not to break things.

<!-- For detailed information on these and other aspects see -->
<!-- the ezomero contribution guidelines. -->
<!-- https://github.com/TheJacksonLaboratory/ezomero/CONTRIBUTING.md -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.

