### PR TITLE
use docker compose v2 on actions

### DIFF
--- a/.github/workflows/run_tests_pr.yml
+++ b/.github/workflows/run_tests_pr.yml
@@ -7,7 +7,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run docker compose up
-        run: docker-compose -f tests/docker-compose.yml up -d
+        run: docker compose -f tests/docker-compose.yml up -d
       - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/run_tests_push.yml
+++ b/.github/workflows/run_tests_push.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run docker compose up
-        run: docker-compose -f tests/docker-compose.yml up -d
+        run: docker compose -f tests/docker-compose.yml up -d
       - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:


### PR DESCRIPTION
## Description

This should fix failing actions by using `docker compose` instead of `docker-compose`. No other changes were made.


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the ezomero contribution guidelines. -->
<!-- https://github.com/TheJacksonLaboratory/ezomero/CONTRIBUTING.md -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.

