### PR TITLE
added GH action for generating docs on release

### DIFF
--- a/.github/workflows/generate_docs.yml
+++ b/.github/workflows/generate_docs.yml
@@ -1,0 +1,35 @@
+name: Sphinx docs to gh-pages
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+jobs:
+  sphinx_docs_to_gh-pages:
+    runs-on: ubuntu-latest
+    name: Sphinx docs to gh-pages
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.9
+      - name: Installing the library
+        shell: bash -l {0}
+        run: |
+          pip install https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp39-cp39-manylinux_2_28_x86_64.whl
+          python setup.py install
+          pip install sphinx
+      - name: Running Sphinx
+        shell: bash -l {0}
+        run: |
+          cd docs/sphinx
+          sphinx-apidoc -f -o source ../../ezomero test
+          sphinx-build -b html source ../
+      - name: Deploy to pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: docs
+          branch: "documentation"


### PR DESCRIPTION
## Description

This PR adds a github action for generating documentation on release using Sphinx and force-pushing it to the `documentation` branch. It will require a minor change in repository settings (from deploying github pages from the `docs` directory to `root` directory in the `documentation` branch). It also allows this action to be run on-demand when a documentation update is necessary.


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the ezomero contribution guidelines. -->
<!-- https://github.com/TheJacksonLaboratory/ezomero/CONTRIBUTING.md -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.

