### PR TITLE
Ezimport fixes

### DIFF
--- a/ezomero/_ezomero.py
+++ b/ezomero/_ezomero.py
@@ -124,14 +124,14 @@ def put_map_annotation(conn: BlitzGateway, map_ann_id: int, kv_dict: dict,
     kv_pairs = []
     for k, v in kv_dict.items():
         k = str(k)
-        if type(v) != list:
+        if type(v) is not list:
             v = str(v)
             kv_pairs.append([k, v])
         else:
             for value in v:
                 value = str(value)
                 kv_pairs.append([k, value])
-                
+
     map_ann.setValue(kv_pairs)
     map_ann.save()
     return None

--- a/ezomero/_gets.py
+++ b/ezomero/_gets.py
@@ -1294,9 +1294,9 @@ def get_map_annotation(conn: BlitzGateway, map_ann_id: int,
     """
     if type(map_ann_id) is not int:
         raise TypeError('Map annotation ID must be an integer')
-    
+
     map_annotation_dict = {}
-    
+
     map_annotation = conn.getObject('MapAnnotation', map_ann_id).getValue()
 
     for item in map_annotation:

--- a/ezomero/_importer.py
+++ b/ezomero/_importer.py
@@ -264,11 +264,10 @@ class Importer:
     3) For automating purposes, the arguments ``host`` and ``port`` can be set,
     avoiding a user prompt for that info. Both need to be set to bypass that
     prompt.
-    4) The returned image IDs correspond to ALL image IDs accessible to this
-    user that have the same ``ClientPath``, i.e., that have the same file
-    name and have been imported from the same folder. In production, this
-    should be a rare occurrence, but please keep that in mind if you are
-    getting more image IDs than you were expecting!
+    4) Due to the method we use for detecting imported image IDs, passing
+    through the `--file` argument to redirect the stdout output of `omero
+    import`is not possible - `--err` to redirect the stderr output should
+    be possible.
     """
 
     def __init__(self, conn: BlitzGateway, file_path: str,
@@ -447,8 +446,7 @@ class Importer:
                      '-k', self.conn.getSession().getUuid().val,
                      '-s', self.conn.host,
                      '-p', str(self.conn.port),
-                     '--file', stdout_file.name,
-                     '--output', 'yaml']
+                     ]
         if self.common_args:
             str_args = ['--{}'.format(v) for v in self.common_args]
             arguments.extend(str_args)
@@ -456,6 +454,7 @@ class Importer:
             str_kwargs = ['--{}={}'.format(k, v) for k, v in
                           self.named_args.items()]
             arguments.extend(str_kwargs)
+        arguments.extend(['--file', stdout_file.name, '--output', 'yaml'])
         arguments.append(str(self.file_path))
         print(arguments)
         cli.invoke(arguments)

--- a/ezomero/_importer.py
+++ b/ezomero/_importer.py
@@ -1,4 +1,6 @@
 import logging
+import tempfile
+import yaml
 from typing import Optional, Union, List
 from os.path import abspath
 from omero.rtypes import rstring
@@ -61,18 +63,19 @@ def ezimport(conn: BlitzGateway, target: str,
 
     imp_ctl = Importer(conn, target, project, dataset, screen,
                        ann, ns, *args, **kwargs)
-    imp_ctl.ezimport()
-    if imp_ctl.screen:
-        imp_ctl.get_plate_ids()
-        imp_ctl.organize_plates()
-        imp_ctl.annotate_plates()
-        return imp_ctl.plate_ids
+    rv = imp_ctl.ezimport()
+    if rv:
+        if imp_ctl.screen:
+            imp_ctl.get_plate_ids()
+            imp_ctl.organize_plates()
+            imp_ctl.annotate_plates()
+            return imp_ctl.plate_ids
 
-    else:
-        imp_ctl.get_my_image_ids()
-        imp_ctl.organize_images()
-        imp_ctl.annotate_images()
-        return imp_ctl.image_ids
+        else:
+            imp_ctl.get_my_image_ids()
+            imp_ctl.organize_images()
+            imp_ctl.annotate_images()
+            return imp_ctl.image_ids
 
 
 def set_or_create_project(conn: BlitzGateway, project: Union[str, int],
@@ -283,6 +286,7 @@ class Importer:
         self.dataset = dataset
         self.common_args = args
         self.named_args = kwargs
+        self.import_result = ""
 
         if self.project and not self.dataset:
             raise ValueError("Cannot define project but no dataset!")
@@ -305,27 +309,8 @@ class Importer:
             Ids of images imported from the specified client path, which
             itself is derived from ``self.file_path`` and ``self.filename``.
         """
-        if self.imported is not True:
-            logging.error(f'File {self.file_path} has not been imported')
-            return None
-        else:
-            q = self.conn.getQueryService()
-            params = Parameters()
-            path_query = self.make_substitutions()
-            path_query = path_query.strip('/')
-            if path_query.endswith(".zarr"):
-                path_query = f"{path_query}/.zattrs"
-            params.map = {"cpath": rstring(path_query)}
-            results = q.projection(
-                "SELECT i.id FROM Image i"
-                " JOIN i.fileset fs"
-                " JOIN fs.usedFiles u"
-                " WHERE u.clientPath=:cpath",
-                params,
-                self.conn.SERVICE_OPTS
-                )
-            self.image_ids = [r[0].val for r in results]
-            return self.image_ids
+        self.image_ids = self.import_result[0]['Image']
+        return self.image_ids
 
     def make_substitutions(self) -> str:
         fpath = self.file_path
@@ -344,32 +329,8 @@ class Importer:
             Ids of plates imported from the specified client path, which
             itself is derived from ``self.file_path`` and ``self.filename``.
         """
-        if self.imported is not True:
-            logging.error(f'File {self.file_path} has not been imported')
-            return None
-        else:
-            print("time to get some IDs")
-            q = self.conn.getQueryService()
-            print(q)
-            params = Parameters()
-            path_query = str(self.file_path).strip('/')
-            print(f"path query: f{path_query}")
-            params.map = {"cpath": rstring(path_query)}
-            print(params)
-            results = q.projection(
-                "SELECT DISTINCT p.id FROM Plate p"
-                " JOIN p.plateAcquisitions pa"
-                " JOIN pa.wellSample ws"
-                " JOIN ws.image i"
-                " JOIN i.fileset fs"
-                " JOIN fs.usedFiles u"
-                " WHERE u.clientPath=:cpath",
-                params,
-                self.conn.SERVICE_OPTS
-                )
-            print(results)
-            self.plate_ids = [r[0].val for r in results]
-            return self.plate_ids
+        self.plate_ids = self.import_result[0]['Plate']
+        return self.plate_ids
 
     def annotate_images(self) -> Union[int, None]:
         """Post map annotation (``self.ann``) to images ``self.image_ids``.
@@ -483,10 +444,13 @@ class Importer:
         cli = CLI()
         cli.register('import', ImportControl, '_')
         cli.register('sessions', SessionsControl, '_')
+        stdout_file = tempfile.NamedTemporaryFile(mode="r")
         arguments = ['import',
                      '-k', self.conn.getSession().getUuid().val,
                      '-s', self.conn.host,
-                     '-p', str(self.conn.port)]
+                     '-p', str(self.conn.port),
+                     '--file', stdout_file.name,
+                     '--output', 'yaml']
         if self.common_args:
             str_args = ['--{}'.format(v) for v in self.common_args]
             arguments.extend(str_args)
@@ -497,7 +461,9 @@ class Importer:
         arguments.append(str(self.file_path))
         print(arguments)
         cli.invoke(arguments)
-        if cli.rv == 0:
+        self.import_result = yaml.safe_load(stdout_file)
+        stdout_file.close()
+        if self.import_result:
             self.imported = True
             print(f'Imported {self.file_path}')
             return True

--- a/ezomero/_importer.py
+++ b/ezomero/_importer.py
@@ -3,8 +3,6 @@ import tempfile
 import yaml
 from typing import Optional, Union, List
 from os.path import abspath
-from omero.rtypes import rstring
-from omero.sys import Parameters
 from omero.gateway import MapAnnotationWrapper, BlitzGateway
 from ._gets import get_image_ids
 from ._posts import post_dataset, post_project, post_screen
@@ -214,7 +212,7 @@ def multi_post_map_annotation(conn: BlitzGateway, object_type: str,
     kv_pairs = []
     for k, v in kv_dict.items():
         k = str(k)
-        if type(v) != list:
+        if type(v) is not list:
             v = str(v)
             kv_pairs.append([k, v])
         else:

--- a/ezomero/_importer.py
+++ b/ezomero/_importer.py
@@ -456,7 +456,6 @@ class Importer:
             arguments.extend(str_kwargs)
         arguments.extend(['--file', stdout_file.name, '--output', 'yaml'])
         arguments.append(str(self.file_path))
-        print(arguments)
         cli.invoke(arguments)
         self.import_result = yaml.safe_load(stdout_file)
         stdout_file.close()

--- a/ezomero/_misc.py
+++ b/ezomero/_misc.py
@@ -17,7 +17,7 @@ def filter_by_filename(conn: BlitzGateway, im_ids: List[int],
 
     Sometimes we know the filename of an image that has been imported into
     OMERO but not necessarily the image ID. This is frequently the case when
-    we want to annotate a recently imported image. This funciton will help
+    we want to annotate a recently imported image. This function will help
     to filter a list of image IDs to only those associated with a particular
     filename.
 

--- a/ezomero/_posts.py
+++ b/ezomero/_posts.py
@@ -276,7 +276,7 @@ def post_map_annotation(conn: BlitzGateway, object_type: str, object_id: int,
     kv_pairs = []
     for k, v in kv_dict.items():
         k = str(k)
-        if type(v) != list:
+        if type(v) is not list:
             v = str(v)
             kv_pairs.append([k, v])
         else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,9 +74,8 @@ def pytest_addoption(parser):
                                             DEFAULT_OMERO_WEB_HOST))
     parser.addoption("--omero-port",
                      action="store",
-                     type=int,
-                     default=int(os.environ.get("OMERO_PORT",
-                                                DEFAULT_OMERO_PORT)))
+                     default=os.environ.get("OMERO_PORT",
+                                            DEFAULT_OMERO_PORT))
     parser.addoption("--omero-secure",
                      action="store",
                      default=bool(os.environ.get("OMERO_SECURE",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,7 @@ DEFAULT_OMERO_USER = "root"
 DEFAULT_OMERO_PASS = "omero"
 DEFAULT_OMERO_HOST = "localhost"
 DEFAULT_OMERO_WEB_HOST = "http://localhost:5080"
-DEFAULT_OMERO_PORT = 6064
+DEFAULT_OMERO_PORT = "6064"
 DEFAULT_OMERO_SECURE = 1
 
 # [[group, permissions], ...]

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
 
   database:

--- a/tests/test_gets.py
+++ b/tests/test_gets.py
@@ -2,7 +2,6 @@ import pytest
 import numpy as np
 import ezomero
 from omero.gateway import TagAnnotationWrapper
-from omero import SecurityViolation
 
 # Test gets
 ###########
@@ -68,10 +67,7 @@ def test_get_image(conn, project_structure, users_groups, pyramid_fixture):
     groupname = users_groups[0][1][0]  # test_group_2
     current_conn = conn.suConn(username, groupname)
     im_id4 = image_info[1][1]  # im1(in test_group_1)
-    im4 = None
-    im_arr4 = None
-    with pytest.raises(SecurityViolation):
-        im4, im_arr4 = ezomero.get_image(current_conn, im_id4)
+    im4, im_arr4 = ezomero.get_image(current_conn, im_id4)
     assert im4 is None
     assert im_arr4 is None
     current_conn.close()
@@ -215,9 +211,7 @@ def test_get_image_ids(conn, project_structure, screen_structure,
     groupname = users_groups[0][1][0]  # test_group_2 (test_user3 is mbr)
     current_conn = conn.suConn(username, groupname)
     ds1_id = dataset_info[1][1]  # ds1, in test_group1 (test_user3 not mbr)
-    ds1_im_ids = None
-    with pytest.raises(SecurityViolation):
-        ds1_im_ids = ezomero.get_image_ids(current_conn, dataset=ds1_id)
+    ds1_im_ids = ezomero.get_image_ids(current_conn, dataset=ds1_id)
     assert not ds1_im_ids
     current_conn.close()
 
@@ -808,9 +802,7 @@ def test_get_roi_ids(conn, project_structure, roi_fixture, users_groups):
     username = users_groups[1][2][0]  # test_user3
     groupname = users_groups[0][1][0]  # test_group_2
     current_conn = conn.suConn(username, groupname)
-    empty_ret = []
-    with pytest.raises(SecurityViolation):
-        empty_ret = ezomero.get_roi_ids(current_conn, im_id)
+    empty_ret = ezomero.get_roi_ids(current_conn, im_id)
     assert empty_ret == []
     current_conn.close()
 
@@ -861,9 +853,7 @@ def test_get_shape_and_get_shape_ids(conn, project_structure,
     username = users_groups[1][2][0]  # test_user3
     groupname = users_groups[0][1][0]  # test_group_2
     current_conn = conn.suConn(username, groupname)
-    empty_ret = None
-    with pytest.raises(SecurityViolation):
-        empty_ret = ezomero.get_shape_ids(current_conn, roi_id)
+    empty_ret = ezomero.get_shape_ids(current_conn, roi_id)
     assert empty_ret is None
     current_conn.close()
 

--- a/tests/test_gets.py
+++ b/tests/test_gets.py
@@ -2,6 +2,7 @@ import pytest
 import numpy as np
 import ezomero
 from omero.gateway import TagAnnotationWrapper
+from omero import SecurityViolation
 
 # Test gets
 ###########
@@ -67,7 +68,10 @@ def test_get_image(conn, project_structure, users_groups, pyramid_fixture):
     groupname = users_groups[0][1][0]  # test_group_2
     current_conn = conn.suConn(username, groupname)
     im_id4 = image_info[1][1]  # im1(in test_group_1)
-    im4, im_arr4 = ezomero.get_image(current_conn, im_id4)
+    im4 = None
+    im_arr4 = None
+    with pytest.raises(SecurityViolation):
+        im4, im_arr4 = ezomero.get_image(current_conn, im_id4)
     assert im4 is None
     assert im_arr4 is None
     current_conn.close()
@@ -211,7 +215,9 @@ def test_get_image_ids(conn, project_structure, screen_structure,
     groupname = users_groups[0][1][0]  # test_group_2 (test_user3 is mbr)
     current_conn = conn.suConn(username, groupname)
     ds1_id = dataset_info[1][1]  # ds1, in test_group1 (test_user3 not mbr)
-    ds1_im_ids = ezomero.get_image_ids(current_conn, dataset=ds1_id)
+    ds1_im_ids = None
+    with pytest.raises(SecurityViolation):
+        ds1_im_ids = ezomero.get_image_ids(current_conn, dataset=ds1_id)
     assert not ds1_im_ids
     current_conn.close()
 
@@ -802,7 +808,9 @@ def test_get_roi_ids(conn, project_structure, roi_fixture, users_groups):
     username = users_groups[1][2][0]  # test_user3
     groupname = users_groups[0][1][0]  # test_group_2
     current_conn = conn.suConn(username, groupname)
-    empty_ret = ezomero.get_roi_ids(current_conn, im_id)
+    empty_ret = []
+    with pytest.raises(SecurityViolation):
+        empty_ret = ezomero.get_roi_ids(current_conn, im_id)
     assert empty_ret == []
     current_conn.close()
 
@@ -853,7 +861,9 @@ def test_get_shape_and_get_shape_ids(conn, project_structure,
     username = users_groups[1][2][0]  # test_user3
     groupname = users_groups[0][1][0]  # test_group_2
     current_conn = conn.suConn(username, groupname)
-    empty_ret = ezomero.get_shape_ids(current_conn, roi_id)
+    empty_ret = None
+    with pytest.raises(SecurityViolation):
+        empty_ret = ezomero.get_shape_ids(current_conn, roi_id)
     assert empty_ret is None
     current_conn.close()
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -3,7 +3,6 @@ import pytest
 from omero.gateway import PlateWrapper
 from omero.model import PlateI
 from omero.gateway import TagAnnotationWrapper
-from omero import SecurityViolation
 
 
 def test_omero_connection(conn, omero_params):
@@ -115,8 +114,8 @@ def test_set_group(conn, users_groups):
     with pytest.raises(TypeError):
         _ = ezomero.set_group(current_conn, '10')
     new_group = users_groups[0][0][1]  # test_group_1
-    with pytest.raises(SecurityViolation):
-        ret = ezomero.set_group(current_conn, int(new_group))
+    ret = ezomero.set_group(current_conn, int(new_group))
+    assert ret is False
     current_conn.close()
 
     username = users_groups[1][0][0]  # test_user1

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -3,6 +3,7 @@ import pytest
 from omero.gateway import PlateWrapper
 from omero.model import PlateI
 from omero.gateway import TagAnnotationWrapper
+from omero import SecurityViolation
 
 
 def test_omero_connection(conn, omero_params):
@@ -114,8 +115,8 @@ def test_set_group(conn, users_groups):
     with pytest.raises(TypeError):
         _ = ezomero.set_group(current_conn, '10')
     new_group = users_groups[0][0][1]  # test_group_1
-    ret = ezomero.set_group(current_conn, int(new_group))
-    assert ret is False
+    with pytest.raises(SecurityViolation):
+        ret = ezomero.set_group(current_conn, int(new_group))
     current_conn.close()
 
     username = users_groups[1][0][0]  # test_user1

--- a/tests/test_posts.py
+++ b/tests/test_posts.py
@@ -67,7 +67,8 @@ def test_post_dataset(conn, project_structure, users_groups, timestamp):
     pid = project_info[1][1]  # proj1 (in test_group_1)
     did5 = None
     with pytest.raises(UnknownException):
-        did5 = ezomero.post_dataset(current_conn, ds_test_name5, project_id=pid)
+        did5 = ezomero.post_dataset(current_conn, ds_test_name5,
+                                    project_id=pid)
     current_conn.close()
     assert did5 is None
 
@@ -227,7 +228,7 @@ def test_post_get_map_annotation(conn, project_structure, users_groups):
     im_id4 = image_info[1][1]  # im1(in test_group_1)
     map_ann_id4 = None
     with pytest.raises(SecurityViolation):
-        map_ann_id4 = ezomero.post_map_annotation(current_conn, "Image", 
+        map_ann_id4 = ezomero.post_map_annotation(current_conn, "Image",
                                                   im_id4, kv, ns)
     assert map_ann_id4 is None
     current_conn.close()
@@ -452,7 +453,7 @@ def test_post_roi(conn, project_structure, roi_fixture, users_groups):
     current_conn = conn.suConn(username, groupname)
     im_id4 = image_info[1][1]  # im1(in test_group_1)
     print(roi_fixture)
-    with pytest.raises(UnknownException): 
+    with pytest.raises(UnknownException):
         _ = ezomero.post_roi(current_conn, im_id4,
                              shapes=roi_fixture['shapes'],
                              name=roi_fixture['name'],

--- a/tests/test_posts.py
+++ b/tests/test_posts.py
@@ -5,8 +5,6 @@ import filecmp
 import os
 import sys
 from unittest import mock
-from omero import SecurityViolation
-from Ice import UnknownException
 
 
 # Test posts
@@ -65,10 +63,10 @@ def test_post_dataset(conn, project_structure, users_groups, timestamp):
     ds_test_name5 = 'test_post_dataset5_' + timestamp
     project_info = project_structure[0]
     pid = project_info[1][1]  # proj1 (in test_group_1)
-    did5 = None
-    with pytest.raises(UnknownException):
-        did5 = ezomero.post_dataset(current_conn, ds_test_name5,
-                                    project_id=pid)
+    did5 = ezomero.post_dataset(current_conn, ds_test_name5,
+                                project_id=pid)
+    ds_ids = ezomero.get_dataset_ids(current_conn)
+    assert len(ds_ids) == 1
     current_conn.close()
     assert did5 is None
 
@@ -157,11 +155,9 @@ def test_post_image(conn, project_structure, users_groups, timestamp,
     dataset_info = project_structure[1]
     did5 = dataset_info[1][1]  # ds1 (in test_group_1)
     image_name = 'test_post_image_' + timestamp
-    im_id5 = None
-    with pytest.raises(UnknownException):
-        im_id5 = ezomero.post_image(current_conn, image_fixture, image_name,
-                                    description='This is an image',
-                                    dataset_id=did5)
+    im_id5 = ezomero.post_image(current_conn, image_fixture, image_name,
+                                description='This is an image',
+                                dataset_id=did5)
     current_conn.close()
     assert im_id5 is None
 
@@ -226,10 +222,8 @@ def test_post_get_map_annotation(conn, project_structure, users_groups):
     groupname = users_groups[0][1][0]  # test_group_2
     current_conn = conn.suConn(username, groupname)
     im_id4 = image_info[1][1]  # im1(in test_group_1)
-    map_ann_id4 = None
-    with pytest.raises(SecurityViolation):
-        map_ann_id4 = ezomero.post_map_annotation(current_conn, "Image",
-                                                  im_id4, kv, ns)
+    map_ann_id4 = ezomero.post_map_annotation(current_conn, "Image",
+                                              im_id4, kv, ns)
     assert map_ann_id4 is None
     current_conn.close()
 
@@ -290,10 +284,8 @@ def test_post_get_comment_annotation(conn, project_structure, users_groups):
     groupname = users_groups[0][1][0]  # test_group_2
     current_conn = conn.suConn(username, groupname)
     im_id4 = image_info[1][1]  # im1(in test_group_1)
-    comm_ann_id4 = None
-    with pytest.raises(SecurityViolation):
-        comm_ann_id4 = ezomero.post_comment_annotation(current_conn, "Image",
-                                                       im_id4, comment, ns)
+    comm_ann_id4 = ezomero.post_comment_annotation(current_conn, "Image",
+                                                   im_id4, comment, ns)
     assert comm_ann_id4 is None
     current_conn.close()
 
@@ -364,11 +356,9 @@ def test_post_get_file_annotation(conn, project_structure, users_groups,
     groupname = users_groups[0][1][0]  # test_group_2
     current_conn = conn.suConn(username, groupname)
     im_id4 = image_info[1][1]  # im1(in test_group_1)
-    file_ann_id4 = None
-    with pytest.raises(SecurityViolation):
-        file_ann_id4 = ezomero.post_file_annotation(current_conn,
-                                                    file_ann, ns,
-                                                    "Image", im_id4)
+    file_ann_id4 = ezomero.post_file_annotation(current_conn,
+                                                file_ann, ns,
+                                                "Image", im_id4)
     assert file_ann_id4 is None
     current_conn.close()
 
@@ -452,8 +442,8 @@ def test_post_roi(conn, project_structure, roi_fixture, users_groups):
     groupname = users_groups[0][1][0]  # test_group_2
     current_conn = conn.suConn(username, groupname)
     im_id4 = image_info[1][1]  # im1(in test_group_1)
-    print(roi_fixture)
-    with pytest.raises(UnknownException):
+    a, b = ezomero.get_image(current_conn, im_id4)
+    with pytest.raises(AttributeError):
         _ = ezomero.post_roi(current_conn, im_id4,
                              shapes=roi_fixture['shapes'],
                              name=roi_fixture['name'],


### PR DESCRIPTION
## Description

This substantially changes the logic `ezimport` uses to find newly imported images/plates, and what it uses to consider an import failed. This should address #122 and #123. It now pipes the output of `omero import` into a yml file and reads that for image/plate IDs; if there's no output, the import has failed. (I have learned a failed import process still returns 0)

(I have also cleaned up any PEP8 infringements.)


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the ezomero contribution guidelines. -->
<!-- https://github.com/TheJacksonLaboratory/ezomero/CONTRIBUTING.md -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.

