### PR TITLE
moves testing to use python=3.11

### DIFF
--- a/.github/workflows/run_tests_pr.yml
+++ b/.github/workflows/run_tests_pr.yml
@@ -8,15 +8,15 @@ jobs:
         uses: actions/checkout@v4
       - name: Run docker compose up
         run: docker compose -f tests/docker-compose.yml up -d
-      - name: Set up Python 3.8
+      - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.11
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install flake8 pytest
-          pip install https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20231130/zeroc_ice-3.6.5-cp38-cp38-manylinux_2_28_x86_64.whl
+          pip install https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp311-cp311-manylinux_2_28_x86_64.whl
           pip install .[tables]
           sleep 60
       - name: Test with pytest

--- a/.github/workflows/run_tests_push.yml
+++ b/.github/workflows/run_tests_push.yml
@@ -12,15 +12,15 @@ jobs:
         uses: actions/checkout@v4
       - name: Run docker compose up
         run: docker compose -f tests/docker-compose.yml up -d
-      - name: Set up Python 3.8
+      - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.11
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install flake8 pytest
-          pip install https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20231130/zeroc_ice-3.6.5-cp38-cp38-manylinux_2_28_x86_64.whl
+          pip install https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp311-cp311-manylinux_2_28_x86_64.whl
           pip install .[tables]
           sleep 60
       - name: Test with pytest and generate coverage report/badge


### PR DESCRIPTION
## Description

Just moving testing from python 3.8 to 3.11, and changing zeroc-ice versions accordingly.


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the ezomero contribution guidelines. -->
<!-- https://github.com/TheJacksonLaboratory/ezomero/CONTRIBUTING.md -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.

