### PR TITLE
Ensure that we only packages files from the ezomero directory

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/TheJacksonLaboratory/ezomero",
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(where="ezomero"),
     install_requires=[
         'omero-py >= 5.13.0, < 5.20.0',
         'numpy >= 1.22, < 2.0'


### PR DESCRIPTION
## Description

<!-- If this is a bug-fix or enhancement, state the issue # it closes -->
<!-- If this is a new feature, reference what it is implementing. -->
Ensure that packages are only added from the ezomero folder, thus excluding the `tests` folder. This is referenced in https://github.com/conda-forge/staged-recipes/pull/25329 and is a condition for adding `ezomero` to `conda-forge`.


## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests
- [x] Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the ezomero contribution guidelines. -->
<!-- https://github.com/TheJacksonLaboratory/ezomero/CONTRIBUTING.md -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.

