### PR TITLE
fix temp file issue on windows

### DIFF
--- a/ezomero/_importer.py
+++ b/ezomero/_importer.py
@@ -459,9 +459,8 @@ class Importer:
         arguments.extend(['--file', stdout_file.name, '--output', 'yaml'])
         arguments.append(str(self.file_path))
         cli.invoke(arguments)
-        f = open(stdout_file.name, 'r')
-        self.import_result = yaml.safe_load(f)
-        f.close()
+        with open(stdout_file.name, 'r') as f:
+            self.import_result = yaml.safe_load(f)
         unlink(stdout_file.name)
         if self.import_result:
             self.imported = True


### PR DESCRIPTION
## Description

From https://docs.python.org/3.9/library/tempfile.html#tempfile.NamedTemporaryFile:

```
Whether the name can be used to open the file a second time, while the named temporary file is still open, varies across platforms (it can be so used on Unix; it cannot on Windows). If delete is true (the default), the file is deleted as soon as it is closed.
```
 At https://github.com/TheJacksonLaboratory/ezomero/blob/aa52ea2976732e510a63ef4bff3b52bd6d23dbc8/ezomero/_importer.py#L444 we create a new file using that function, that is then passed as an argument to `omero import`, which does an `open` operation on it. As expected from the documentation, that works on Unix, but doesn't on Windows, causing a permission denied error. 

The workaround involves creating the temp file with `delete=False` (i.e. not deleting it upon closing), closing it, then passing it to `omero import` - it opens and closes that file, so we reopen it to pass it to `yaml.safe_load` for parsing, close it again, and delete it.



## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

<!-- For detailed information on these and other aspects see -->
<!-- the ezomero contribution guidelines. -->
<!-- https://github.com/TheJacksonLaboratory/ezomero/CONTRIBUTING.md -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.

