### PR TITLE
[maint] Fix docs build action and sphinx build warnings

### DIFF
--- a/.github/workflows/generate_docs.yml
+++ b/.github/workflows/generate_docs.yml
@@ -20,8 +20,7 @@ jobs:
         shell: bash -l {0}
         run: |
           pip install https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp39-cp39-manylinux_2_28_x86_64.whl
-          python setup.py install
-          pip install sphinx
+          pip install .[docs]
       - name: Running Sphinx
         shell: bash -l {0}
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,15 @@ dmypy.json
 
 # For my sanity, I have a local script to run tests
 run_tests.sh
+
+# Ignore docs build files
+docs/*.html
+docs/_sources
+docs/_static
+docs/.doctrees
+docs/.buildinfo
+docs/.nojekyll
+docs/objects.inv
+docs/searchindex.js
+docs/sphinx/source/ezomero.rst
+docs/sphinx/source/modules.rst

--- a/docs/sphinx/source/conf.py
+++ b/docs/sphinx/source/conf.py
@@ -59,4 +59,4 @@ html_theme = 'alabaster'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']

--- a/ezomero/_ezomero.py
+++ b/ezomero/_ezomero.py
@@ -222,16 +222,12 @@ def connect(user: Optional[str] = None, password: Optional[str] = None,
     ----------
     user : str, optional
         OMERO username.
-
     password : str, optional
         OMERO password.
-
     group : str, optional
         OMERO group.
-
     host : str, optional
         OMERO.server host.
-
     port : int, optional
         OMERO port.
 

--- a/ezomero/_ezomero.py
+++ b/ezomero/_ezomero.py
@@ -381,24 +381,18 @@ def store_connection_params(user: Optional[str] = None,
     ----------
     user : str, optional
         OMERO username.
-
     group : str, optional
         OMERO group.
-
     host : str, optional
         OMERO.server host.
-
     port : int, optional
         OMERO port.
-
     secure : boolean, optional
         Whether to create a secure session.
-
     web_host : boolean/str, optional
         Whether to save a web host address got JSON connections as well. If
         `False`, will skip it; it `True`, will prompt user for it; if it is
         a `str`, will save that value to `OMERO_WEB_HOST`.
-
     config_path : str, optional
         Path to directory that will contain the '.ezomero' file. If left as
         ``None``, defaults to the home directory as determined by Python's

--- a/ezomero/json_api.py
+++ b/ezomero/json_api.py
@@ -29,20 +29,15 @@ def create_json_session(user: Optional[str] = None,
     ----------
     user : str, optional
         OMERO username.
-
     password : str, optional
         OMERO password.
-
     web_host : str, optional
         OMERO.web host.
-
     verify : boolean, optional
         Whether to verify SSL certificates when making requests.
-
     server_name : str, optional
         OMERO server name as configured in your OMERO.web installation. For
         a "default" OMERO.web installation, it will normally be 'omero'.
-
     config_path : str, optional
         Path to directory containing '.ezomero' file that stores connection
         information. If left as ``None``, defaults to the home directory as
@@ -52,11 +47,9 @@ def create_json_session(user: Optional[str] = None,
     -------
     login_rsp : JSON object
         JSON containing the response to the ``POST`` request sent for log in.
-
     session : ``requests`` Session object or None
         The effective ``requests`` session that will be used for further
         requests to the JSON API.
-
     base_url : str or None
         Base URL for further requests, retrieved via JSON API request
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ requires-python = ">=3.8"
 
 [project.optional-dependencies]
 tables = ["pandas"]
+docs = ["sphinx"]
 
 [project.urls]
 Repository = "https://github.com/TheJacksonLaboratory/ezomero"


### PR DESCRIPTION
## Description
Currently the docs are not being built correctly: the website has no documentation and search finds nothing.

In this PR I:
1. add `[docs]` as an optional dependency -- it's just sphinx for now
2. Properly pip install the package using `.[docs]` in the build action
Additionally -- and I can split this off -- I make 2 changes to silence warnings in the build:
1. comment out the custom `_static` location, because it's not used
2. remove empty lines in two numpy docstrings that are not proper numpy docstring style

Considerations for followup to catch possible docs issues early:
1. build docs on PR or on merge to main
2. have the build fail on warnings

Considerations for future QoL:
- put all the build output into a dedicated _build directory instead of intermingled in /docs

## Checklist

N/A

## For reviewers


