### PR TITLE
Fix post/get_table not closed

### DIFF
--- a/ezomero/_gets.py
+++ b/ezomero/_gets.py
@@ -1704,6 +1704,7 @@ def get_table(conn: BlitzGateway, file_ann_id: int,
         try:
             table_obj = resources.openTable(orig_table_file._obj)
             table = _create_table(table_obj)
+            table_obj.close()
         except InternalException:
             logging.warning(f" FileAnnotation {file_ann_id} is not a table.")
     else:

--- a/ezomero/_posts.py
+++ b/ezomero/_posts.py
@@ -694,13 +694,13 @@ def post_table(conn: BlitzGateway, table: Any,
     table = resources.newTable(repository_id, table_name)
     table.initialize(columns)
     table.addData(columns)
-    table.close()
     orig_file = table.getOriginalFile()
     file_ann = FileAnnotationWrapper(conn)
     file_obj = OriginalFileWrapper(conn, orig_file)
     file_obj.save()
     file_ann.setFile(file_obj)
     file_ann = obj.linkAnnotation(file_ann)
+    table.close()
     return file_ann.id
 
 

--- a/ezomero/_posts.py
+++ b/ezomero/_posts.py
@@ -694,6 +694,7 @@ def post_table(conn: BlitzGateway, table: Any,
     table = resources.newTable(repository_id, table_name)
     table.initialize(columns)
     table.addData(columns)
+    table.close()
     orig_file = table.getOriginalFile()
     file_ann = FileAnnotationWrapper(conn)
     file_obj = OriginalFileWrapper(conn, orig_file)


### PR DESCRIPTION
## Description
When posting a table with ezomero I encountered the issue that the table appeared as zero bytes in OMERO.web . Only after opening the table once it appears as a fully initialized table. I also encountered issues with projects containing such tables using the omero-cli-transfer tool.
It seems the issue is that upon submitting a table the table should be closed, following the upstream omero-py library.

## Checklist
No new functions are introduced and I have run the tests locally.
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.

